### PR TITLE
Fix type casting for max_input_id to ensure consistent uint64 handling

### DIFF
--- a/src/cellmap_analyze/process/fill_holes.py
+++ b/src/cellmap_analyze/process/fill_holes.py
@@ -73,7 +73,7 @@ class FillHoles(ComputeConfigMixin):
             holes, mode="inner", connectivity=connectivity
         ).astype(np.uint64)
 
-        max_input_id = np.max(input)
+        max_input_id = np.max(input).astype(np.uint64)
         holes = holes.astype(np.uint64)
         holes[holes > 0] += max_input_id  # so there is no id overlap
         data = holes + input


### PR DESCRIPTION
This pull request makes a minor update to the `get_hole_information_blockwise` function in `src/cellmap_analyze/process/fill_holes.py` to ensure type consistency when calculating the maximum input ID.

* The result of `np.max(input)` is now explicitly cast to `np.uint64`, ensuring that subsequent operations involving `holes` and `input` do not encounter type mismatches.