### PR TITLE
Gaussian filter

### DIFF
--- a/tests/operations/test_connected_components.py
+++ b/tests/operations/test_connected_components.py
@@ -2,7 +2,7 @@ import pytest
 from scipy import ndimage
 from skimage import measure
 from cellmap_analyze.process.connected_components import ConnectedComponents
-
+from scipy.ndimage import gaussian_filter
 import numpy as np
 
 from cellmap_analyze.util.image_data_interface import (
@@ -207,6 +207,47 @@ def test_binarize(tmp_zarr, binarizable_image, binarize):
     ground_truth = cc3d.connected_components(
         binarizable_image, binary_image=binarize, connectivity=6
     )
+
+    assert np.array_equal(
+        test_data,
+        ground_truth,
+    )
+
+
+@pytest.mark.parametrize(
+    "gaussian_smoothing_radius_voxels",
+    [1, 2, 4],
+)
+def test_gaussian_smoothing(
+    tmp_zarr,
+    intensity_image,
+    voxel_size,
+    gaussian_smoothing_radius_voxels,
+):
+    gaussian_smoothing_radius_nm = gaussian_smoothing_radius_voxels * voxel_size
+    cc = ConnectedComponents(
+        input_path=f"{tmp_zarr}/intensity_image/s0",
+        output_path=f"{tmp_zarr}/test_connected_components_gaussian_smoothing_radius_nm_{gaussian_smoothing_radius_nm}",
+        intensity_threshold_minimum=5,
+        gaussian_smoothing_radius_nm=gaussian_smoothing_radius_nm,
+        num_workers=1,
+        connectivity=1,
+    )
+    cc.get_connected_components()
+
+    smoothed_image = (
+        gaussian_filter(
+            intensity_image.astype(np.float32),
+            sigma=gaussian_smoothing_radius_voxels,
+            mode="constant",
+            cval=0,
+        )
+        > 5
+    )
+    ground_truth = cc3d.connected_components(smoothed_image, connectivity=6)
+    test_data = ImageDataInterface(
+        f"{tmp_zarr}/test_connected_components_gaussian_smoothing_radius_nm_{gaussian_smoothing_radius_nm}/s0"
+    ).to_ndarray_ts()
 
     assert np.array_equal(
         test_data,


### PR DESCRIPTION
@stuarteberg

This pull request introduces support for Gaussian smoothing in the connected components workflow, allowing users to specify a smoothing radius before thresholding and labeling. The main changes include updates to the `ConnectedComponents` class and its blockwise processing logic to handle Gaussian smoothing, as well as new tests to verify correct behavior.

### Connected Components Processing Enhancements
* Added a `gaussian_smoothing_radius_nm` parameter to the `ConnectedComponents` class and its blockwise calculation methods, enabling optional Gaussian smoothing of input data prior to thresholding and connected component labeling. [[1]](diffhunk://#diff-eaf59a5df0dee7db4bea99ef549cdd7769ff94a6bc3a851e60d9c9f6be26b237R44) [[2]](diffhunk://#diff-eaf59a5df0dee7db4bea99ef549cdd7769ff94a6bc3a851e60d9c9f6be26b237R129) [[3]](diffhunk://#diff-eaf59a5df0dee7db4bea99ef549cdd7769ff94a6bc3a851e60d9c9f6be26b237R163) [[4]](diffhunk://#diff-eaf59a5df0dee7db4bea99ef549cdd7769ff94a6bc3a851e60d9c9f6be26b237R278)
* Updated block creation and processing logic to handle padding when smoothing is applied, ensuring border effects are minimized and results are consistent.

### Data Handling and Mask Logic
* Refactored mask handling in blockwise processing to ensure masks are correctly applied after smoothing and trimming, maintaining compatibility with existing workflows. [[1]](diffhunk://#diff-eaf59a5df0dee7db4bea99ef549cdd7769ff94a6bc3a851e60d9c9f6be26b237L191-R220) [[2]](diffhunk://#diff-eaf59a5df0dee7db4bea99ef549cdd7769ff94a6bc3a851e60d9c9f6be26b237L201-R230)

### Testing
* Added new parameterized test `test_gaussian_smoothing` to verify connected components results with different Gaussian smoothing radii, ensuring output matches ground truth computed with direct smoothing and labeling.
* Updated imports in test files to support new functionality.
