### PR TITLE
Fix MWS memory issues and dask scheduler OOM

### DIFF
--- a/src/cellmap_analyze/process/mutex_watershed.py
+++ b/src/cellmap_analyze/process/mutex_watershed.py
@@ -153,13 +153,13 @@ class MutexWatershed(ComputeConfigMixin):
 
     @staticmethod
     def filter_fragments(
-        affs_data: np.ndarray, fragments_data: np.ndarray, filter_val: float
+        average_affs: np.ndarray, fragments_data: np.ndarray, filter_val: float
     ) -> None:
-        """Allows filtering of MWS fragments based on mean value of affinities & fragments. Will filter and update the fragment array in-place.
+        """Filter MWS fragments based on mean affinity value. Updates fragments in-place.
 
         Args:
-            aff_data (``np.ndarray``):
-                An array containing affinity data.
+            average_affs (``np.ndarray``):
+                Mean affinities across channels, shape matching spatial dims of fragments.
 
             fragments_data (``np.ndarray``):
                 An array containing fragment data.
@@ -167,9 +167,6 @@ class MutexWatershed(ComputeConfigMixin):
             filter_val (``float``):
                 Threshold to filter if the average value falls below.
         """
-
-        average_affs: float = np.mean(affs_data.data, axis=0)
-
         filtered_fragments: list = []
 
         fragment_ids: np.ndarray = np.unique(fragments_data)
@@ -183,7 +180,6 @@ class MutexWatershed(ComputeConfigMixin):
         filtered_fragments: np.ndarray = np.array(
             filtered_fragments, dtype=fragments_data.dtype
         )
-        # replace: np.ndarray = np.zeros_like(filtered_fragments)
         fastremap.mask(fragments_data, filtered_fragments, in_place=True)
 
     @staticmethod
@@ -191,7 +187,6 @@ class MutexWatershed(ComputeConfigMixin):
         affinities, neighborhood, adjacent_edge_bias, lr_bias, filter_val
     ):
         if affinities.dtype == np.uint8:
-            # logger.info("Assuming affinities are in [0,255]")
             max_affinity_value: float = 255.0
             affinities = affinities.astype(np.float64)
         else:
@@ -201,16 +196,23 @@ class MutexWatershed(ComputeConfigMixin):
         affinities /= max_affinity_value
 
         if affinities.max() < 1e-4:
-            segmentation = np.zeros(affinities.shape[1:], dtype=np.uint64)
-            return segmentation
+            return np.zeros(affinities.shape[1:], dtype=np.uint64)
 
-        random_noise = np.random.randn(*affinities.shape) * 0.0001
-        smoothed_affs = (
-            ndimage.gaussian_filter(
-                affinities, sigma=(0, *(np.amax(neighborhood, axis=0) / 3))
-            )
-            - 0.5
-        ) * 0.001
+        # Pre-compute average for filter_fragments before modifying affinities
+        average_affs = np.mean(affinities, axis=0) if filter_val > 0.0 else None
+
+        # Compute gaussian smoothing into a separate buffer, then accumulate
+        smoothed = np.empty_like(affinities)
+        ndimage.gaussian_filter(
+            affinities, sigma=(0, *(np.amax(neighborhood, axis=0) / 3)),
+            output=smoothed,
+        )
+        smoothed -= 0.5
+        smoothed *= 0.001
+        affinities += smoothed
+        del smoothed
+
+        # Add shift in-place
         shift = []
         bias_idx = -1
         previous_offset = np.linalg.norm(neighborhood[0])
@@ -227,15 +229,17 @@ class MutexWatershed(ComputeConfigMixin):
                     shift.append(current_offset * lr_bias)
             previous_offset = current_offset
         shift = np.array(shift).reshape((-1, *((1,) * (len(affinities.shape) - 1))))
+        affinities += shift
 
-        # filter fragments
-        segmentation = mws.agglom(
-            affinities + shift + random_noise + smoothed_affs,
-            offsets=neighborhood,
-        )
+        # Add noise per-channel to avoid allocating a full copy
+        for i in range(affinities.shape[0]):
+            affinities[i] += np.random.randn(*affinities.shape[1:]) * 0.0001
+
+        segmentation = mws.agglom(affinities, offsets=neighborhood)
+        del affinities
 
         if filter_val > 0.0:
-            MutexWatershed.filter_fragments(affinities, segmentation, filter_val)
+            MutexWatershed.filter_fragments(average_affs, segmentation, filter_val)
         # fragment_ids = fastremap.unique(segmentation[segmentation > 0])
         # fastremap.mask_except(segmentation, filtered_fragments, in_place=True)
         fastremap.renumber(segmentation, in_place=True)
@@ -277,17 +281,13 @@ class MutexWatershed(ComputeConfigMixin):
             block_index,
             padding=padding,
         )
-        logger.info(
-            f"Block {block_index}: read_roi={block.read_roi}, write_roi={block.write_roi}"
-        )
-
         if mask:
             mask_block = mask.process_block(roi=block.read_roi)
             if not mask_block.any():
                 connected_components_blockwise_idi.ds[block.write_roi] = 0
+                return
 
         # Support list of IDIs (one per affinity channel) or single 4D IDI
-        logger.info(f"Block {block_index}: reading affinities...")
         if isinstance(affinities_idi, list):
             affinities = np.stack(
                 [idi.to_ndarray_ts(block.read_roi) for idi in affinities_idi],
@@ -295,15 +295,15 @@ class MutexWatershed(ComputeConfigMixin):
             )
         else:
             affinities = affinities_idi.to_ndarray_ts(block.read_roi)
-        logger.info(
-            f"Block {block_index}: affinities loaded, shape={affinities.shape}, "
-            f"dtype={affinities.dtype}, mem={affinities.nbytes / 1e6:.1f} MB"
-        )
 
         if mask:
             affinities *= mask_block[None, :, :, :]
 
-        logger.info(f"Block {block_index}: running mutex watershed...")
+        # Skip blocks with no signal before expensive float64 conversion
+        if affinities.max() == 0:
+            connected_components_blockwise_idi.ds[block.write_roi] = 0
+            return
+
         segmentation = MutexWatershed.mutex_watershed(
             affinities=affinities,
             neighborhood=neighborhood,
@@ -311,11 +311,9 @@ class MutexWatershed(ComputeConfigMixin):
             lr_bias=lr_bias,
             filter_val=filter_val,
         )
-        logger.info(f"Block {block_index}: running connected components...")
         segmentation = MutexWatershed.instancewise_instance_segmentation(
             segmentation, connectivity=connectivity, do_opening=do_opening
         )
-        logger.info(f"Block {block_index}: done, writing output...")
 
         # Calculate offset with per-axis division for anisotropic data
         global_id_offset = np.uint64(

--- a/src/cellmap_analyze/util/dask_util.py
+++ b/src/cellmap_analyze/util/dask_util.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 import os
 import random
 import dask
-from dask.distributed import Client, wait
+from dask.distributed import Client
 import getpass
 import tempfile
 import shutil
@@ -563,27 +563,8 @@ def compute_blockwise_partitions(
     with start_dask(num_workers, msg, logger):
         with TimingMessager(msg.capitalize(), logger):
             try:
-                # This will block until everything finishes (or errors),
-                # then return the in-memory result or raise.
-                if num_workers == 1:
-                    bag.compute(**compute_args)
-
-                else:
-                    futures = bag.persist(**compute_args)
-                    [completed, _] = wait(futures)
-                    failed = [f for f in completed if f.exception() is not None]
-
-                    # cancel so errors from shutdown don't propagate
-                    for completed_future in completed:
-                        completed_future.cancel()
-
-                    if failed:
-                        raise RuntimeError(
-                            f"Failed to compute {len(failed)} blocks: {failed}"
-                        )
-
+                bag.compute(**compute_args)
             except Exception as e:
-                # Any other Python-level exception your function raised
                 print("Compute raised an exception:", e)
                 raise
 

--- a/src/cellmap_analyze/util/image_data_interface.py
+++ b/src/cellmap_analyze/util/image_data_interface.py
@@ -250,6 +250,9 @@ def to_ndarray_tensorstore(
         )
     )
 
+    # Check if the ROI has no overlap with the dataset
+    no_overlap = any(vs.start > vs.stop for vs in valid_slices)
+
     pad_width = [
         [valid_slice.start - s.start, s.stop - valid_slice.stop]
         for s, valid_slice in zip(roi_slices, valid_slices)
@@ -266,6 +269,21 @@ def to_ndarray_tensorstore(
         fill_value = 0
     if custom_fill_value:
         fill_value = custom_fill_value
+
+    if no_overlap:
+        if needs_rescaling:
+            # Use output voxel space for the shape
+            output_shape = (
+                ([dataset.shape[0]] if channel_offset > 0 else [])
+                + [int(round(original_roi.shape[i] / output_voxel_size[i])) for i in range(3)]
+            )
+        else:
+            output_shape = (
+                ([dataset.shape[0]] if channel_offset > 0 else [])
+                + [s.stop - s.start for s in roi_slices]
+            )
+        fv = 0 if fill_value == "edge" else fill_value
+        return np.full(output_shape, fv, dtype=dataset.dtype.numpy_dtype)
 
     # with ts.Transaction() as txn:
     try:


### PR DESCRIPTION
@stuarteberg
Revert dask from persist()+wait() to bag.compute() to fix scheduler OOM at scale (720 GB on 234K blocks/480 workers). The FIRST_COMPLETED wait loop accumulated scheduler state over thousands of iterations.

Reduce MWS worker memory by ~4 GB per block via in-place operations: accumulate gaussian, shift, and noise into affinities array directly, pre-compute average_affs for filter_fragments, and free affinities after agglom.

Add early returns in calculate_block_connected_components for empty mask blocks and zero-affinity blocks.

Fix tensorstore crash when block ROI has no overlap with dataset (e.g. mask with non-zero offset). Return correctly-shaped fill-value array accounting for voxel size rescaling.