### PR TITLE
Targeted erosion

### DIFF
--- a/src/cellmap_analyze/analyze/assign_to_organelles.py
+++ b/src/cellmap_analyze/analyze/assign_to_organelles.py
@@ -2,7 +2,7 @@
 from typing import Union, List
 from cellmap_analyze.util import io_util
 from cellmap_analyze.util.io_util import (
-    get_name_from_path,
+    get_leaf_name_from_path,
     get_output_path_from_input_path,
 )
 from cellmap_analyze.util.image_data_interface import (
@@ -47,7 +47,7 @@ class AssignToOrganelles:
             self.organelle_info_dict[organelle_csv] = df
 
         self.organelle_idi = ImageDataInterface(target_organelle_ds_path)
-        self.organelle_name = get_name_from_path(target_organelle_ds_path).capitalize()
+        self.organelle_name = get_leaf_name_from_path(target_organelle_ds_path).capitalize()
         self.assignment_type = assignment_type
         self.output_path = str(output_path).rstrip("/")
         self.iteration_distance_nm = iteration_distance_nm

--- a/src/cellmap_analyze/analyze/measure.py
+++ b/src/cellmap_analyze/analyze/measure.py
@@ -8,7 +8,7 @@ from cellmap_analyze.util.dask_util import (
 from cellmap_analyze.util.image_data_interface import ImageDataInterface
 from cellmap_analyze.util.information_holders import ObjectInformation
 from cellmap_analyze.util.io_util import (
-    get_name_from_path,
+    get_leaf_name_from_path,
 )
 import pandas as pd
 import logging
@@ -110,7 +110,7 @@ class Measure(ComputeConfigMixin):
             self.get_measurements_blockwise_extra_kwargs["raw_idi"] = self.raw_idi
 
         # Handle root datasets (empty name) by using "data" as default
-        input_name = get_name_from_path(self.input_path)
+        input_name = get_leaf_name_from_path(self.input_path)
         if not input_name:
             input_name = "data"
         self.output_directory = (
@@ -259,7 +259,7 @@ class Measure(ComputeConfigMixin):
 
     def write_measurements(self):
         os.makedirs(self.output_path, exist_ok=True)
-        file_name = get_name_from_path(self.input_path)
+        file_name = get_leaf_name_from_path(self.input_path)
         # Handle root datasets (empty name) by using "measurements" as filename
         if not file_name:
             file_name = "measurements"
@@ -283,8 +283,8 @@ class Measure(ComputeConfigMixin):
             columns += ["Mean Intensity", "Std Intensity"]
 
         if self.contact_sites:
-            organelle_1_name = get_name_from_path(self.organelle_1_path)
-            organelle_2_name = get_name_from_path(self.organelle_2_path)
+            organelle_1_name = get_leaf_name_from_path(self.organelle_1_path)
+            organelle_2_name = get_leaf_name_from_path(self.organelle_2_path)
             # Handle root datasets (empty names) by using defaults
             if not organelle_1_name:
                 organelle_1_name = "organelle_1"

--- a/src/cellmap_analyze/process/contact_sites.py
+++ b/src/cellmap_analyze/process/contact_sites.py
@@ -4,7 +4,7 @@ from cellmap_analyze.util.dask_util import (
     create_block_from_index,
 )
 from cellmap_analyze.util.image_data_interface import ImageDataInterface
-from cellmap_analyze.util.io_util import get_name_from_path, get_output_path_from_input_path
+from cellmap_analyze.util.io_util import get_leaf_name_from_path, get_output_path_from_input_path
 from cellmap_analyze.cythonizing.process_arrays import initialize_contact_site_array
 from cellmap_analyze.cythonizing.bresenham3D import bresenham_3D_lines
 import logging
@@ -92,10 +92,10 @@ class ContactSites(ComputeConfigMixin):
         if self.roi is None:
             self.roi = self.organelle_1_idi.roi.intersect(self.organelle_2_idi.roi)
 
-        if not get_name_from_path(output_path):
+        if not get_leaf_name_from_path(output_path):
             output_path = (
                 output_path
-                + f"/{get_name_from_path(organelle_1_path)}_{get_name_from_path(organelle_2_path)}_contacts"
+                + f"/{get_leaf_name_from_path(organelle_1_path)}_{get_leaf_name_from_path(organelle_2_path)}_contacts"
             )
 
         self.output_path = str(output_path).rstrip("/")

--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -111,6 +111,9 @@ def remove_unbridged_adjacencies(data, connectivity=6):
     checks whether they share a bridging voxel at the desired connectivity
     level. If not, the voxel is marked for removal.
 
+    Uses a Cython implementation when available (much faster for large arrays),
+    falling back to a numpy vectorized version otherwise.
+
     Args:
         data: 3D boolean array.
         connectivity: 6 — keep only face-adjacent connections; remove voxels

--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -23,6 +23,125 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+# --- Unbridged adjacency removal helpers ---
+#
+# Two voxels can be adjacent in three ways:
+#   face-adjacent   (6-conn):  differ in 1 axis, share a face
+#   edge-adjacent   (18-conn): differ in 2 axes, share an edge
+#   vertex-adjacent (26-conn): differ in 3 axes, share only a corner point
+#
+# A "bridge" is a third voxel that is face-adjacent (or edge-adjacent,
+# depending on mode) to BOTH voxels in a pair. If at least one bridge
+# voxel is foreground, the pair is connected at the desired connectivity
+# without relying on the weaker adjacency.
+#
+# Only half the directions are listed (first nonzero component positive)
+# because the A->B and B->A relationships are symmetric.
+
+# Edge-adjacent pairs and their face bridges.
+# For an offset like (1,1,0), the 2 face bridges are found by zeroing
+# each nonzero component: (1,0,0) and (0,1,0).
+_EDGE_ADJ_FACE_BRIDGES = [
+    ((1, 1, 0), [(1, 0, 0), (0, 1, 0)]),
+    ((1, -1, 0), [(1, 0, 0), (0, -1, 0)]),
+    ((1, 0, 1), [(1, 0, 0), (0, 0, 1)]),
+    ((1, 0, -1), [(1, 0, 0), (0, 0, -1)]),
+    ((0, 1, 1), [(0, 1, 0), (0, 0, 1)]),
+    ((0, 1, -1), [(0, 1, 0), (0, 0, -1)]),
+]
+
+# Vertex-adjacent pairs and their face bridges only.
+# For an offset like (1,1,1), the 3 face bridges are found by keeping
+# one nonzero component at a time: (1,0,0), (0,1,0), (0,0,1).
+_VERTEX_ADJ_FACE_BRIDGES = [
+    ((1, 1, 1), [(1, 0, 0), (0, 1, 0), (0, 0, 1)]),
+    ((1, 1, -1), [(1, 0, 0), (0, 1, 0), (0, 0, -1)]),
+    ((1, -1, 1), [(1, 0, 0), (0, -1, 0), (0, 0, 1)]),
+    ((1, -1, -1), [(1, 0, 0), (0, -1, 0), (0, 0, -1)]),
+]
+
+# Vertex-adjacent pairs with all bridges (3 face + 3 edge = 6 per pair).
+# Edge bridges are found by keeping two nonzero components at a time:
+# e.g. for (1,1,1) -> (1,1,0), (1,0,1), (0,1,1).
+_VERTEX_ADJ_ALL_BRIDGES = [
+    (
+        (1, 1, 1),
+        [(1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 1, 0), (1, 0, 1), (0, 1, 1)],
+    ),
+    (
+        (1, 1, -1),
+        [(1, 0, 0), (0, 1, 0), (0, 0, -1), (1, 1, 0), (1, 0, -1), (0, 1, -1)],
+    ),
+    (
+        (1, -1, 1),
+        [(1, 0, 0), (0, -1, 0), (0, 0, 1), (1, -1, 0), (1, 0, 1), (0, -1, 1)],
+    ),
+    (
+        (1, -1, -1),
+        [(1, 0, 0), (0, -1, 0), (0, 0, -1), (1, -1, 0), (1, 0, -1), (0, -1, -1)],
+    ),
+]
+
+
+def _shift(data, dz, dy, dx):
+    """Shift a 3D boolean array by (dz, dy, dx), filling vacated edges with False."""
+    result = np.zeros_like(data)
+    sz_src, sz_dst = _shift_slices(dz, data.shape[0])
+    sy_src, sy_dst = _shift_slices(dy, data.shape[1])
+    sx_src, sx_dst = _shift_slices(dx, data.shape[2])
+    result[sz_dst, sy_dst, sx_dst] = data[sz_src, sy_src, sx_src]
+    return result
+
+
+def _shift_slices(delta, size):
+    """Return (source_slice, dest_slice) for a shift of `delta` along an axis of `size`."""
+    if delta > 0:
+        return slice(0, size - delta), slice(delta, size)
+    elif delta < 0:
+        return slice(-delta, size), slice(0, size + delta)
+    else:
+        return slice(None), slice(None)
+
+
+def remove_unbridged_adjacencies(data, connectivity=6):
+    """Remove foreground voxels whose only connection to a neighbor is weaker
+    than the specified connectivity.
+
+    For each pair of edge-adjacent or vertex-adjacent foreground voxels,
+    checks whether they share a bridging voxel at the desired connectivity
+    level. If not, the voxel is marked for removal.
+
+    Args:
+        data: 3D boolean array.
+        connectivity: 6 — keep only face-adjacent connections; remove voxels
+                          that are only edge- or vertex-adjacent without a
+                          face bridge.
+                      18 — keep face- and edge-adjacent connections; remove
+                           voxels that are only vertex-adjacent without a
+                           face or edge bridge.
+
+    Returns:
+        Modified boolean array with unbridged voxels removed.
+    """
+    if connectivity == 6:
+        pairs = _EDGE_ADJ_FACE_BRIDGES + _VERTEX_ADJ_FACE_BRIDGES
+    elif connectivity == 18:
+        pairs = _VERTEX_ADJ_ALL_BRIDGES
+    else:
+        raise ValueError(f"connectivity must be 6 or 18, got {connectivity}")
+
+    to_remove = np.zeros_like(data)
+    for offset, bridges in pairs:
+        neighbor = _shift(data, *offset)
+        any_bridge = np.zeros_like(data)
+        for b in bridges:
+            any_bridge |= _shift(data, *b)
+        problem = data & neighbor & ~any_bridge
+        to_remove |= problem
+
+    return data & ~to_remove
+
+
 class Skeletonize(ComputeConfigMixin):
     def __init__(
         self,
@@ -44,7 +163,11 @@ class Skeletonize(ComputeConfigMixin):
             csv_path: Path to CSV containing bounding box info with columns:
                      MIN X (nm), MIN Y (nm), MIN Z (nm), MAX X (nm), MAX Y (nm), MAX Z (nm)
                      and index column for IDs
-            erosion: Whether to apply binary erosion before skeletonization
+            erosion: Controls pre-skeletonization erosion.
+                     True or "full": standard binary erosion with 6-connectivity cross SE.
+                     6: targeted removal of edge/vertex-only bridges (keep face-connected).
+                     18: targeted removal of vertex-only bridges (keep face+edge-connected).
+                     False or None: no erosion.
             min_branch_length_nm: Minimum branch length for pruning (in nm)
             tolerance_nm: Tolerance for simplification (in nm)
             num_workers: Number of parallel workers
@@ -54,6 +177,19 @@ class Skeletonize(ComputeConfigMixin):
         self.segmentation_idi = ImageDataInterface(segmentation_path, timeout=timeout)
         self.output_path = str(output_path).rstrip("/")
         self.csv_path = csv_path
+        # Normalize erosion parameter
+        if erosion is True:
+            erosion = "full"
+        elif erosion is False or erosion is None:
+            erosion = None
+        elif erosion in (6, 18):
+            erosion = str(erosion)
+        elif erosion in ("full", "6", "18"):
+            pass
+        else:
+            raise ValueError(
+                f"erosion must be True, False, None, 'full', 6, 18, '6', or '18', got {erosion!r}"
+            )
         self.erosion = erosion
         self.min_branch_length_nm = min_branch_length_nm
         self.tolerance_nm = tolerance_nm
@@ -88,7 +224,7 @@ class Skeletonize(ComputeConfigMixin):
         segmentation_idi: ImageDataInterface,
         bbox_df: pd.DataFrame,
         output_path: str,
-        erosion: bool,
+        erosion: str,
         min_branch_length_nm: float,
         tolerance_nm: float,
     ):
@@ -100,7 +236,7 @@ class Skeletonize(ComputeConfigMixin):
             segmentation_idi: ImageDataInterface for the segmentation
             bbox_df: DataFrame with bounding box information
             output_path: Base output path
-            erosion: Whether to apply erosion
+            erosion: Erosion mode ("full", "6", "18", or None)
             min_branch_length_nm: Minimum branch length for pruning
             tolerance_nm: Tolerance for simplification
         """
@@ -152,7 +288,7 @@ class Skeletonize(ComputeConfigMixin):
             distance_transform = edt_module.edt(data, anisotropy=tuple(isotropic_voxel_size))
 
             # Apply erosion if requested
-            if erosion:
+            if erosion == "full":
                 # Define a 3D cross-shaped structuring element (6-connectivity)
                 cross_3d = np.array(
                     [
@@ -163,7 +299,12 @@ class Skeletonize(ComputeConfigMixin):
                     dtype=bool,
                 )
                 data = binary_erosion(data, cross_3d)
+            elif erosion == "6":
+                data = remove_unbridged_adjacencies(data, connectivity=6)
+            elif erosion == "18":
+                data = remove_unbridged_adjacencies(data, connectivity=18)
 
+            if erosion is not None:
                 # Check if erosion removed everything
                 if not np.any(data):
                     logger.warning(

--- a/src/cellmap_analyze/util/image_data_interface.py
+++ b/src/cellmap_analyze/util/image_data_interface.py
@@ -250,11 +250,12 @@ def to_ndarray_tensorstore(
             slice(snapped_offset[i], snapped_end[i]) for i in range(3)
         )
 
-    roi = roi.snap_to_grid(voxel_size)
+    # Subtract offset before snapping so snap_to_grid aligns to the
+    # actual voxel boundaries (offset, offset+vs, offset+2*vs, …)
+    # instead of (0, vs, 2*vs, …).
     roi -= offset
+    roi = roi.snap_to_grid(voxel_size)
     roi /= voxel_size
-
-    # in the event that we are passing things at half voxel offsets, we need to snap the roi to the grid
 
     # Specify the range
     roi_slices = roi.to_slices()

--- a/src/cellmap_analyze/util/io_util.py
+++ b/src/cellmap_analyze/util/io_util.py
@@ -57,6 +57,31 @@ def get_name_from_path(path):
     return data_name
 
 
+def get_leaf_name_from_path(path):
+    """Get just the leaf dataset name, ignoring nesting within the container.
+
+    Examples:
+        "/path/data.zarr/nested/dataset/s0" -> "dataset"
+        "/path/data.zarr/dataset/s0" -> "dataset"
+        "/path/data.zarr/s0" -> ""
+        "/path/data.zarr" -> ""
+        "/path/to/dataset/s0" -> "dataset"  (no .zarr/.n5)
+        "/path/to/dataset" -> "dataset"  (no .zarr/.n5, no scale)
+    """
+    path = str(path).rstrip("/")
+
+    if ".zarr" in path or ".n5" in path:
+        name = get_name_from_path(path)
+    else:
+        # No zarr/n5 extension — strip scale and take last component
+        stripped = split_on_last_scale(path)
+        name = os.path.basename(stripped) if stripped else ""
+
+    if "/" in name:
+        return name.rsplit("/", 1)[1]
+    return name
+
+
 def split_dataset_path(dataset_path, scale=None) -> tuple[str, str]:
     """Split the dataset path into the filename and dataset
 

--- a/tests/operations/conftest.py
+++ b/tests/operations/conftest.py
@@ -447,6 +447,19 @@ def segmentation_for_skeleton():
 
     seg[z_plane, 44:47, 18:20] = 7
 
+    # ID 8: C-shape that wraps back and touches itself at a diagonal corner
+    # Two thick arms connected through a base, tips touch only diagonally.
+    # Base: horizontal bar
+    seg[35:38, 40:43, 35:45] = 8
+    # Left arm going up
+    seg[35:38, 43:48, 35:38] = 8
+    # Right arm going up
+    seg[35:38, 43:48, 42:45] = 8
+    # Tips touch diagonally at (35:38, 48, 38) and (35:38, 48, 42)
+    # but NOT at faces -- add the very tip voxels so they are corner-adjacent
+    seg[36, 48, 38] = 8
+    seg[36, 48, 41] = 8
+
     return seg
 
 

--- a/tests/operations/test_io_util.py
+++ b/tests/operations/test_io_util.py
@@ -11,6 +11,7 @@ from cellmap_analyze.util.io_util import (
     split_on_last_scale,
     split_dataset_path,
     get_name_from_path,
+    get_leaf_name_from_path,
     get_output_path_from_input_path,
 )
 
@@ -103,6 +104,50 @@ class TestGetNameFromPath:
     def test_n5_format(self):
         """Test extracting name from n5 format."""
         name = get_name_from_path("/path/data.n5/dataset/s0")
+        assert name == "dataset"
+
+
+class TestGetLeafNameFromPath:
+    """Test the get_leaf_name_from_path function."""
+
+    def test_normal_dataset(self):
+        name = get_leaf_name_from_path("/path/data.zarr/dataset/s0")
+        assert name == "dataset"
+
+    def test_nested_dataset(self):
+        name = get_leaf_name_from_path("/path/data.zarr/nested/dataset/s0")
+        assert name == "dataset"
+
+    def test_deeply_nested_dataset(self):
+        name = get_leaf_name_from_path("/path/data.zarr/a/b/c/s0")
+        assert name == "c"
+
+    def test_root_dataset(self):
+        name = get_leaf_name_from_path("/path/data.zarr/s0")
+        assert name == ""
+
+    def test_without_scale(self):
+        name = get_leaf_name_from_path("/path/data.zarr/dataset")
+        assert name == "dataset"
+
+    def test_n5_format(self):
+        name = get_leaf_name_from_path("/path/data.n5/nested/dataset/s0")
+        assert name == "dataset"
+
+    def test_zarr_is_dataset(self):
+        name = get_leaf_name_from_path("/path/data.zarr")
+        assert name == ""
+
+    def test_zarr_is_dataset_with_scale(self):
+        name = get_leaf_name_from_path("/path/data.zarr/s0")
+        assert name == ""
+
+    def test_no_zarr_with_scale(self):
+        name = get_leaf_name_from_path("/path/to/dataset/s0")
+        assert name == "dataset"
+
+    def test_no_zarr_without_scale(self):
+        name = get_leaf_name_from_path("/path/to/dataset")
         assert name == "dataset"
 
 

--- a/tests/operations/test_skeletonize.py
+++ b/tests/operations/test_skeletonize.py
@@ -80,8 +80,18 @@ def compute_reference_skeleton(
     if not np.any(data):
         return None
 
+    from cellmap_analyze.process.skeletonize import remove_unbridged_adjacencies
+
+    # Normalize erosion parameter (same as Skeletonize.__init__)
+    if erosion is True:
+        erosion = "full"
+    elif erosion is False or erosion is None:
+        erosion = None
+    elif erosion in (6, 18):
+        erosion = str(erosion)
+
     # Apply erosion if requested
-    if erosion:
+    if erosion == "full":
         cross_3d = np.array(
             [
                 [[0, 0, 0], [0, 1, 0], [0, 0, 0]],
@@ -91,6 +101,10 @@ def compute_reference_skeleton(
             dtype=bool,
         )
         data = binary_erosion(data, cross_3d)
+    elif erosion == "6":
+        data = remove_unbridged_adjacencies(data, connectivity=6)
+    elif erosion == "18":
+        data = remove_unbridged_adjacencies(data, connectivity=18)
 
     if not np.any(data):
         return None
@@ -160,11 +174,11 @@ def test_skeletonize_single_worker(tmp_zarr, tmp_skeletonize_csv):
             seg_props = json.load(f)
             assert seg_props["@type"] == "neuroglancer_segment_properties"
             assert "ids" in seg_props["inline"]
-            assert set(seg_props["inline"]["ids"]) == {"1", "2", "3", "4", "5", "6", "7"}
+            assert set(seg_props["inline"]["ids"]) == {"1", "2", "3", "4", "5", "6", "7", "8"}
 
     # Check that skeleton files were created for all IDs (including empty skeletons)
     # Note: Some IDs (like ID 7 figure-8) may be completely removed by erosion and written as empty skeletons
-    ids = [1, 2, 3, 4, 5, 6, 7]
+    ids = [1, 2, 3, 4, 5, 6, 7, 8]
     for id_val in ids:
         # All IDs should have skeleton files (even if empty)
         full_path = f"{output_path}/full/{id_val}"
@@ -199,7 +213,7 @@ def test_skeletonize_produces_reasonable_skeletons(
     skeletonizer.skeletonize()
 
     # For each ID, verify the skeleton has reasonable properties
-    ids = [1, 2, 3, 4, 5, 6, 7]
+    ids = [1, 2, 3, 4, 5, 6, 7, 8]
     for id_val in ids:
         test_skeleton_path = f"{output_path}/full/{id_val}"
 
@@ -286,7 +300,7 @@ def test_skeletonize_without_erosion(tmp_zarr, tmp_skeletonize_csv, voxel_size):
     # for certain block cross-sections (e.g. 6x6, 8x6, 4x4) due to symmetric
     # surface removal. After isotropic resampling, small objects (IDs 1-3) may
     # hit these problematic dimensions and lose their skeletons entirely.
-    ids = [1, 2, 3, 4, 5, 6, 7]
+    ids = [1, 2, 3, 4, 5, 6, 7, 8]
     ids_with_vertices = []
     for id_val in ids:
         full_path = f"{output_path}/full/{id_val}"
@@ -414,7 +428,7 @@ def test_skeletonize_with_roi_padding(tmp_zarr, tmp_skeletonize_csv, voxel_size)
     # For each ID, verify that the skeleton is within the expected bounds
     df = pd.read_csv(tmp_skeletonize_csv, index_col=0)
 
-    for id_val in [1, 2, 3, 4, 5, 6]:
+    for id_val in [1, 2, 3, 4, 5, 6, 8]:
         test_skeleton_path = f"{output_path}/full/{id_val}"
         if not os.path.exists(test_skeleton_path):
             continue
@@ -602,3 +616,211 @@ def test_skeletonize_preserves_loops(tmp_zarr, tmp_skeletonize_csv, voxel_size):
             f"Figure-8 with {len(cycles)} loops should have at least 1 branch point, "
             f"but found {branch_points}"
         )
+
+
+# =============================================================================
+# Unit tests for remove_unbridged_adjacencies
+# =============================================================================
+
+
+class TestRemoveUnbridgedAdjacencies:
+    """Unit tests for the remove_unbridged_adjacencies function."""
+
+    def test_edge_adjacent_no_bridge_removed_conn6(self):
+        """Two voxels edge-adjacent with no face bridge should have one removed at connectivity=6."""
+        from cellmap_analyze.process.skeletonize import remove_unbridged_adjacencies
+
+        data = np.zeros((5, 5, 5), dtype=bool)
+        data[1, 1, 1] = True
+        data[2, 2, 1] = True  # edge-adjacent via (1,1,0), no face bridge
+        result = remove_unbridged_adjacencies(data, connectivity=6)
+        # At least one should be removed
+        assert result.sum() < data.sum()
+
+    def test_edge_adjacent_with_bridge_kept_conn6(self):
+        """Two voxels edge-adjacent WITH a face bridge should both be kept at connectivity=6."""
+        from cellmap_analyze.process.skeletonize import remove_unbridged_adjacencies
+
+        data = np.zeros((5, 5, 5), dtype=bool)
+        data[1, 1, 1] = True
+        data[2, 2, 1] = True  # edge-adjacent
+        data[2, 1, 1] = True  # face bridge between them
+        result = remove_unbridged_adjacencies(data, connectivity=6)
+        assert result.sum() == data.sum()
+
+    def test_corner_adjacent_no_bridge_removed_both_modes(self):
+        """Two voxels vertex-adjacent with no bridge should have one removed in both modes."""
+        from cellmap_analyze.process.skeletonize import remove_unbridged_adjacencies
+
+        data = np.zeros((5, 5, 5), dtype=bool)
+        data[1, 1, 1] = True
+        data[2, 2, 2] = True  # vertex-adjacent, no bridges
+
+        result_6 = remove_unbridged_adjacencies(data, connectivity=6)
+        assert result_6.sum() < data.sum()
+
+        result_18 = remove_unbridged_adjacencies(data, connectivity=18)
+        assert result_18.sum() < data.sum()
+
+    def test_corner_adjacent_with_edge_bridge_only(self):
+        """Vertex-adjacent pair with edge bridge only: kept for conn=18, removed for conn=6."""
+        from cellmap_analyze.process.skeletonize import remove_unbridged_adjacencies
+
+        data = np.zeros((5, 5, 5), dtype=bool)
+        data[1, 1, 1] = True
+        data[2, 2, 2] = True  # vertex-adjacent
+        data[2, 2, 1] = True  # edge bridge (differs in 2 axes from [1,1,1])
+
+        # connectivity=18: edge bridge exists, should keep both original voxels
+        result_18 = remove_unbridged_adjacencies(data, connectivity=18)
+        assert result_18[1, 1, 1] and result_18[2, 2, 2]
+
+        # connectivity=6: the edge bridge voxel (2,2,1) is itself only
+        # edge-connected to (1,1,1), so it gets removed. But A and B survive
+        # this single pass because (2,2,1) was still present when checked.
+        result_6 = remove_unbridged_adjacencies(data, connectivity=6)
+        assert not result_6[2, 2, 1]  # edge bridge removed
+        # A and B both survive the single pass (bridge was present when checked)
+        assert result_6[1, 1, 1] and result_6[2, 2, 2]
+
+    def test_solid_cube_unchanged(self):
+        """A solid cube should have no voxels removed (all neighbors are face-bridged)."""
+        from cellmap_analyze.process.skeletonize import remove_unbridged_adjacencies
+
+        data = np.zeros((10, 10, 10), dtype=bool)
+        data[2:6, 2:6, 2:6] = True
+        original_count = data.sum()
+
+        result_6 = remove_unbridged_adjacencies(data, connectivity=6)
+        assert result_6.sum() == original_count
+
+        result_18 = remove_unbridged_adjacencies(data, connectivity=18)
+        assert result_18.sum() == original_count
+
+    def test_c_shape_diagonal_broken_body_intact(self):
+        """A C-shape touching itself at a diagonal should have the diagonal broken."""
+        from cellmap_analyze.process.skeletonize import remove_unbridged_adjacencies
+
+        data = np.zeros((7, 12, 12), dtype=bool)
+        # Base
+        data[2:5, 2:5, 2:10] = True
+        # Left arm
+        data[2:5, 5:10, 2:5] = True
+        # Right arm
+        data[2:5, 5:10, 7:10] = True
+        # Tips touch diagonally
+        data[3, 10, 5] = True
+        data[3, 10, 6] = True
+
+        original_count = data.sum()
+        result = remove_unbridged_adjacencies(data, connectivity=6)
+
+        # Should remove the diagonal-only tip voxels but keep the body
+        assert result.sum() < original_count
+        # Body should be intact
+        assert result[2:5, 2:5, 2:10].all()
+        assert result[2:5, 5:10, 2:5].all()
+        assert result[2:5, 5:10, 7:10].all()
+
+    def test_invalid_connectivity_raises(self):
+        """Invalid connectivity value should raise ValueError."""
+        from cellmap_analyze.process.skeletonize import remove_unbridged_adjacencies
+
+        data = np.zeros((3, 3, 3), dtype=bool)
+        with pytest.raises(ValueError):
+            remove_unbridged_adjacencies(data, connectivity=26)
+
+
+# =============================================================================
+# Integration tests for new erosion modes
+# =============================================================================
+
+
+def test_skeletonize_diagonal_6_erosion(tmp_zarr, tmp_skeletonize_csv):
+    """Test skeletonization with connectivity=6 erosion mode."""
+    output_path = tmp_zarr + "/test_skeletonize_diagonal_6"
+
+    skeletonizer = Skeletonize(
+        segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+        output_path=output_path,
+        csv_path=tmp_skeletonize_csv,
+        erosion=6,
+        min_branch_length_nm=0,
+        tolerance_nm=0,
+        num_workers=1,
+    )
+
+    skeletonizer.skeletonize()
+
+    # Check that skeleton files were created for all IDs
+    for id_val in [1, 2, 3, 4, 5, 6, 7, 8]:
+        full_path = f"{output_path}/full/{id_val}"
+        simplified_path = f"{output_path}/simplified/{id_val}"
+        assert os.path.exists(full_path), f"Full skeleton missing for ID {id_val}"
+        assert os.path.exists(simplified_path), f"Simplified skeleton missing for ID {id_val}"
+
+
+def test_skeletonize_diagonal_18_erosion(tmp_zarr, tmp_skeletonize_csv):
+    """Test skeletonization with connectivity=18 erosion mode."""
+    output_path = tmp_zarr + "/test_skeletonize_diagonal_18"
+
+    skeletonizer = Skeletonize(
+        segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+        output_path=output_path,
+        csv_path=tmp_skeletonize_csv,
+        erosion=18,
+        min_branch_length_nm=0,
+        tolerance_nm=0,
+        num_workers=1,
+    )
+
+    skeletonizer.skeletonize()
+
+    # Check that skeleton files were created for all IDs
+    for id_val in [1, 2, 3, 4, 5, 6, 7, 8]:
+        full_path = f"{output_path}/full/{id_val}"
+        simplified_path = f"{output_path}/simplified/{id_val}"
+        assert os.path.exists(full_path), f"Full skeleton missing for ID {id_val}"
+        assert os.path.exists(simplified_path), f"Simplified skeleton missing for ID {id_val}"
+
+
+def test_skeletonize_backward_compat_erosion_true(tmp_zarr, tmp_skeletonize_csv):
+    """Test that erosion=True still works (backward compatibility)."""
+    output_path = tmp_zarr + "/test_skeletonize_compat_true"
+
+    skeletonizer = Skeletonize(
+        segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+        output_path=output_path,
+        csv_path=tmp_skeletonize_csv,
+        erosion=True,
+        min_branch_length_nm=0,
+        tolerance_nm=0,
+        num_workers=1,
+    )
+
+    assert skeletonizer.erosion == "full"
+    skeletonizer.skeletonize()
+
+    for id_val in [1, 2, 3, 4, 5, 6, 7, 8]:
+        assert os.path.exists(f"{output_path}/full/{id_val}")
+
+
+def test_skeletonize_backward_compat_erosion_false(tmp_zarr, tmp_skeletonize_csv):
+    """Test that erosion=False still works (backward compatibility)."""
+    output_path = tmp_zarr + "/test_skeletonize_compat_false"
+
+    skeletonizer = Skeletonize(
+        segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+        output_path=output_path,
+        csv_path=tmp_skeletonize_csv,
+        erosion=False,
+        min_branch_length_nm=0,
+        tolerance_nm=0,
+        num_workers=1,
+    )
+
+    assert skeletonizer.erosion is None
+    skeletonizer.skeletonize()
+
+    for id_val in [1, 2, 3, 4, 5, 6, 7, 8]:
+        assert os.path.exists(f"{output_path}/full/{id_val}")


### PR DESCRIPTION
@stuarteberg
This pull request introduces a new utility function, `get_leaf_name_from_path`, and systematically replaces the previous `get_name_from_path` usage throughout the codebase for improved dataset name extraction. Additionally, it enhances the skeletonization process by adding new, targeted erosion modes that more precisely control voxel connectivity, and provides robust testing for these changes. There are also improvements to ROI grid alignment and expanded test coverage for edge cases.

**Path handling and naming improvements:**

* Added the `get_leaf_name_from_path` function in `io_util.py` to accurately extract only the leaf dataset name, ignoring container nesting and scale, and replaced all usages of `get_name_from_path` with this new function in analysis, measurement, and contact site processing modules. [[1]](diffhunk://#diff-053aa46538be51f98902c3c5c758f97323f71c1697191ef62f0a313e9b92c8d7R60-R84) [[2]](diffhunk://#diff-bdf2574ef5c8f93174dd90bad34705ddc3f2998b1552c17397ac39629061a8c6L5-R5) [[3]](diffhunk://#diff-bdf2574ef5c8f93174dd90bad34705ddc3f2998b1552c17397ac39629061a8c6L50-R50) [[4]](diffhunk://#diff-6682b66d77f1fd0ab242bb38341f78f3c3658307148ccf7d6972ff39c48ed2c4L11-R11) [[5]](diffhunk://#diff-6682b66d77f1fd0ab242bb38341f78f3c3658307148ccf7d6972ff39c48ed2c4L113-R113) [[6]](diffhunk://#diff-6682b66d77f1fd0ab242bb38341f78f3c3658307148ccf7d6972ff39c48ed2c4L262-R262) [[7]](diffhunk://#diff-6682b66d77f1fd0ab242bb38341f78f3c3658307148ccf7d6972ff39c48ed2c4L286-R287) [[8]](diffhunk://#diff-21f101b7264159d1ecd23ada8aae014aeb0a582666007e4a43c255bf4c33b97cL7-R7) [[9]](diffhunk://#diff-21f101b7264159d1ecd23ada8aae014aeb0a582666007e4a43c255bf4c33b97cL95-R98)
* Added comprehensive unit tests for `get_leaf_name_from_path` covering various path formats and edge cases.

**Skeletonization and erosion enhancements:**

* Introduced new targeted erosion modes in `skeletonize.py`: `"6"` and `"18"`, which remove voxels only connected via edge or vertex adjacency, respectively, improving the control over pre-skeletonization connectivity. Updated the `Skeletonize` class and its `calculate_id_skeleton` method to support these options. [[1]](diffhunk://#diff-a6735a1848d109578324910d0c6a4b47bbc482b9fdd3272539e126ad9c3390b4R26-R147) [[2]](diffhunk://#diff-a6735a1848d109578324910d0c6a4b47bbc482b9fdd3272539e126ad9c3390b4L47-R173) [[3]](diffhunk://#diff-a6735a1848d109578324910d0c6a4b47bbc482b9fdd3272539e126ad9c3390b4R183-R195) [[4]](diffhunk://#diff-a6735a1848d109578324910d0c6a4b47bbc482b9fdd3272539e126ad9c3390b4L91-R230) [[5]](diffhunk://#diff-a6735a1848d109578324910d0c6a4b47bbc482b9fdd3272539e126ad9c3390b4L103-R242) [[6]](diffhunk://#diff-a6735a1848d109578324910d0c6a4b47bbc482b9fdd3272539e126ad9c3390b4L155-R294) [[7]](diffhunk://#diff-a6735a1848d109578324910d0c6a4b47bbc482b9fdd3272539e126ad9c3390b4R305-R310)
* Added the `remove_unbridged_adjacencies` function and supporting helpers to implement these new erosion modes.

**Testing and validation:**

* Expanded test segmentation to include a new structure (ID 8) that tests diagonal-only connectivity, and updated tests to verify correct skeletonization behavior with the new erosion modes and dataset name extraction. [[1]](diffhunk://#diff-a43627ab749e9205d3521aab681373c510eeabb4cfc377782d7cad004f234714R450-R462) [[2]](diffhunk://#diff-9d7c62f3ad351e18dbd7b4db63aef623f5749d4352ca82a8072ad32d90880564R83-R94) [[3]](diffhunk://#diff-9d7c62f3ad351e18dbd7b4db63aef623f5749d4352ca82a8072ad32d90880564R104-R107) [[4]](diffhunk://#diff-9d7c62f3ad351e18dbd7b4db63aef623f5749d4352ca82a8072ad32d90880564L163-R181)

**ROI and grid alignment fix:**

* Improved voxel grid alignment in `to_ndarray_tensorstore` by adjusting the order of ROI offset and grid snapping, ensuring correct subvolume extraction even for non-origin-aligned datasets.