### PR TITLE
Fix coordinate-space and axis-order bugs for fractional voxel sizes and N5

### DIFF
--- a/src/cellmap_analyze/analyze/assign_to_organelles.py
+++ b/src/cellmap_analyze/analyze/assign_to_organelles.py
@@ -301,10 +301,12 @@ class AssignToOrganelles(ComputeConfigMixin):
 
     def assign_to_containing_organelle(self, df, organelle_name):
         coms = df[["COM Z (nm)", "COM Y (nm)", "COM X (nm)"]].to_numpy()
-        coms_path = self._save_coms_to_tmp(coms)
+        sf = self.organelle_idi.voxel_size_scale_factor
+        coms_scaled = coms * sf
+        coms_path = self._save_coms_to_tmp(coms_scaled)
 
         block_to_com_rows, _ = self._group_coms_by_block(
-            coms, self.organelle_idi
+            coms_scaled, self.organelle_idi
         )
         block_indices = sorted(block_to_com_rows.keys())
 
@@ -335,7 +337,9 @@ class AssignToOrganelles(ComputeConfigMixin):
 
     def assign_to_n_nearest_organelles(self, df, n, organelle_name):
         coms = df[["COM Z (nm)", "COM Y (nm)", "COM X (nm)"]].to_numpy()
-        coms_path = self._save_coms_to_tmp(coms)
+        sf = self.organelle_idi.voxel_size_scale_factor
+        coms_scaled = coms * sf
+        coms_path = self._save_coms_to_tmp(coms_scaled)
 
         voxel_size = np.array(self.organelle_idi.voxel_size)
         chunk_shape = np.array(self.organelle_idi.chunk_shape)
@@ -350,7 +354,7 @@ class AssignToOrganelles(ComputeConfigMixin):
         )
 
         block_to_com_rows, _ = self._group_coms_by_block(
-            coms, self.organelle_idi
+            coms_scaled, self.organelle_idi
         )
         block_indices = sorted(block_to_com_rows.keys())
 
@@ -386,11 +390,11 @@ class AssignToOrganelles(ComputeConfigMixin):
             df[dist_col] = [[] for _ in range(len(df))]
             for row_idx, result in results.items():
                 df.at[row_idx, id_col] = result["ids"].tolist()
-                df.at[row_idx, dist_col] = result["distances"].tolist()
+                df.at[row_idx, dist_col] = (result["distances"] / sf).tolist()
         else:
             for row_idx, result in results.items():
                 df.at[row_idx, id_col] = int(result["ids"][0])
-                df.at[row_idx, dist_col] = float(result["distances"][0])
+                df.at[row_idx, dist_col] = float(result["distances"][0] / sf)
 
     def assign_to_organelles(self):
         with io_util.TimingMessager("Assigning objects to organelles", logger):

--- a/src/cellmap_analyze/analyze/assign_to_organelles.py
+++ b/src/cellmap_analyze/analyze/assign_to_organelles.py
@@ -407,7 +407,7 @@ class AssignToOrganelles(ComputeConfigMixin):
                     )
                     continue
                 dist_col = f"{self.organelle_name} Distance (nm)"
-                df[dist_col] = 0
+                df[dist_col] = 0.0
                 self.assign_to_n_nearest_organelles(
                     df, self.assignment_type, self.organelle_name
                 )

--- a/src/cellmap_analyze/util/image_data_interface.py
+++ b/src/cellmap_analyze/util/image_data_interface.py
@@ -179,6 +179,15 @@ def to_ndarray_tensorstore(
     if output_voxel_size is None:
         output_voxel_size = voxel_size
 
+    if swap_axes:
+        print("Swapping axes")
+        if roi:
+            roi = Roi(roi.begin[::-1], roi.shape[::-1])
+        if offset:
+            offset = Coordinate(offset[::-1])
+        voxel_size = Coordinate(voxel_size[::-1])
+        output_voxel_size = Coordinate(output_voxel_size[::-1])
+
     # Calculate per-axis rescale factors for anisotropic data
     rescale_factors = tuple(vs / ovs for vs, ovs in zip(voxel_size, output_voxel_size))
 
@@ -186,13 +195,6 @@ def to_ndarray_tensorstore(
     needs_rescaling = any(rf != 1 for rf in rescale_factors)
     # For fast-path direction (up vs down), use first axis as representative
     rescale_factor = rescale_factors[0]
-
-    if swap_axes:
-        print("Swapping axes")
-        if roi:
-            roi = Roi(roi.begin[::-1], roi.shape[::-1])
-        if offset:
-            offset = Coordinate(offset[::-1])
 
     channel_offset = 0
     domain = dataset.domain
@@ -235,6 +237,8 @@ def to_ndarray_tensorstore(
                     # Mixed up/down per axis — use zoom for correctness
                     zoom_factors = (1,) * channel_offset + rescale_factors
                     data = zoom(data, zoom=zoom_factors, order=interpolation_order)
+        if swap_axes:
+            data = np.swapaxes(data, 0 + channel_offset, 2 + channel_offset)
         return data
 
     if offset is None:
@@ -301,7 +305,10 @@ def to_ndarray_tensorstore(
                 + [s.stop - s.start for s in roi_slices]
             )
         fv = 0 if fill_value == "edge" else fill_value
-        return np.full(output_shape, fv, dtype=dataset.dtype.numpy_dtype)
+        data = np.full(output_shape, fv, dtype=dataset.dtype.numpy_dtype)
+        if swap_axes:
+            data = np.swapaxes(data, 0 + channel_offset, 2 + channel_offset)
+        return data
 
     # with ts.Transaction() as txn:
     try:
@@ -462,6 +469,8 @@ class ImageDataInterface:
         self.ts = None
         self.dtype = self.ds.dtype
         self.chunk_shape = self.ds.chunk_shape
+        if self.swap_axes:
+            self.chunk_shape = Coordinate(self.chunk_shape[::-1])
         if chunk_shape is not None:
             if type(chunk_shape) != Coordinate:
                 chunk_shape = Coordinate(chunk_shape)
@@ -479,6 +488,13 @@ class ImageDataInterface:
             raw_voxel_size = raw_voxel_size[n_extra:]
             raw_offset = raw_offset[n_extra:]
 
+        # For N5, metadata (pixelResolution, dimensions) is in X,Y,Z order.
+        # Reverse to Z,Y,X so the IDI presents a consistent convention
+        # matching zarr and the rest of the codebase (COMs, ROIs, etc.).
+        if self.swap_axes:
+            raw_voxel_size = raw_voxel_size[::-1]
+            raw_offset = raw_offset[::-1]
+
         # Scale float voxel sizes to integers for funlib compatibility
         scaled_vs, scale_factor = scale_voxel_size_to_integers(raw_voxel_size)
         self.original_voxel_size = raw_voxel_size
@@ -488,6 +504,8 @@ class ImageDataInterface:
 
         # Recompute ROI in scaled physical coordinates from the array shape
         array_shape = self.ds.data.shape[-n_spatial:]
+        if self.swap_axes:
+            array_shape = array_shape[::-1]
         scaled_offset = Coordinate(
             int(round(o * scale_factor)) for o in raw_offset
         )
@@ -529,6 +547,8 @@ class ImageDataInterface:
         self.voxel_size = Coordinate(scaled_vs)
 
         array_shape = self.ds.data.shape[-3:]
+        if self.swap_axes:
+            array_shape = array_shape[::-1]
         scaled_offset = Coordinate(
             int(round(o * new_scale_factor)) for o in self._raw_offset
         )

--- a/tests/operations/test_assign_to_organelles.py
+++ b/tests/operations/test_assign_to_organelles.py
@@ -36,7 +36,7 @@ def gt_assignments(organelle_csv, target_organelle_ds_path, n):
     df_com = pd.read_csv(organelle_csv)
     # Extract COM coordinates in (Z, Y, X) order to match organelle_coords.
     coms = df_com[["COM Z (nm)", "COM Y (nm)", "COM X (nm)"]].to_numpy()
-    com_coords = np.array(coms // organelle_idi.voxel_size, dtype=int)
+    com_coords = np.array(coms // np.array(organelle_idi.original_voxel_size), dtype=int)
 
     # Prepare lists to store the assignments for each object.
     assignment_ids = []
@@ -53,7 +53,7 @@ def gt_assignments(organelle_csv, target_organelle_ds_path, n):
     organelle_indices = np.argwhere(organelle_data)
 
     # Compute the physical coordinates by scaling indices with voxel size.
-    organelle_coords = (organelle_indices + 0.5) * organelle_idi.voxel_size
+    organelle_coords = (organelle_indices + 0.5) * np.array(organelle_idi.original_voxel_size)
 
     # Extract the corresponding organelle IDs from the organelle_data array.
     organelle_ids = organelle_data[tuple(organelle_indices.T)]

--- a/tests/operations/test_image_data_interface_non_integer.py
+++ b/tests/operations/test_image_data_interface_non_integer.py
@@ -1,3 +1,7 @@
+import json
+import os
+import struct
+
 import numpy as np
 import pytest
 from cellmap_analyze.util.image_data_interface import (
@@ -435,3 +439,120 @@ class TestCrossDatasetAlignment:
         assert result_A.shape == expected_shape, (
             f"Expected shape {expected_shape}, got {result_A.shape}"
         )
+
+
+def _create_n5_dataset(base_path, shape, block_size, voxel_size_xyz, data):
+    """Create a minimal N5 dataset with raw chunks that tensorstore can read."""
+    os.makedirs(base_path, exist_ok=True)
+
+    attrs = {
+        "dimensions": list(shape),
+        "blockSize": list(block_size),
+        "dataType": "uint8",
+        "compression": {"type": "raw"},
+        "pixelResolution": {"dimensions": voxel_size_xyz, "unit": "nm"},
+    }
+    with open(os.path.join(base_path, "attributes.json"), "w") as f:
+        json.dump(attrs, f)
+
+    bs = block_size
+    for xi in range(0, shape[0], bs[0]):
+        for yi in range(0, shape[1], bs[1]):
+            for zi in range(0, shape[2], bs[2]):
+                chunk_data = data[xi : xi + bs[0], yi : yi + bs[1], zi : zi + bs[2]]
+                chunk_path = os.path.join(
+                    base_path,
+                    str(xi // bs[0]),
+                    str(yi // bs[1]),
+                    str(zi // bs[2]),
+                )
+                os.makedirs(os.path.dirname(chunk_path), exist_ok=True)
+                # N5 raw chunk: mode(2B) + ndim(2B) + dim_sizes(4B each) + data
+                header = struct.pack(">HH", 0, 3)
+                for d in chunk_data.shape:
+                    header += struct.pack(">I", d)
+                with open(chunk_path, "wb") as f:
+                    f.write(header)
+                    f.write(chunk_data.tobytes())
+
+
+@pytest.fixture
+def tmp_n5(tmp_path):
+    """Create an N5 dataset with anisotropic non-integer voxel sizes (4, 4, 5.24)."""
+    n5_path = str(tmp_path / "test.n5")
+    os.makedirs(n5_path)
+    with open(os.path.join(n5_path, "attributes.json"), "w") as f:
+        json.dump({"n5": "2.0.0"}, f)
+
+    labels_path = os.path.join(n5_path, "labels")
+    os.makedirs(labels_path)
+    with open(os.path.join(labels_path, "attributes.json"), "w") as f:
+        json.dump({}, f)
+
+    # N5 dimensions/pixelResolution are in x,y,z order
+    data = np.random.randint(1, 10, (20, 25, 10), dtype=np.uint8)
+    _create_n5_dataset(
+        os.path.join(n5_path, "labels", "s0"),
+        shape=[20, 25, 10],
+        block_size=[10, 10, 10],
+        voxel_size_xyz=[4.0, 4.0, 5.24],
+        data=data,
+    )
+    return os.path.join(n5_path, "labels/s0")
+
+
+class TestN5AnisotropicSwapAxes:
+    """Test that N5 datasets with anisotropic voxel sizes read correct shapes.
+
+    N5 format requires axis swapping (swap_axes=True). When voxel sizes are
+    anisotropic, the swap must also apply to voxel_size so that snap_to_grid
+    uses the correct component per axis.
+    """
+
+    def test_single_voxel_roi_z_axis(self, tmp_n5):
+        """A 1-voxel-thick ROI in z should return shape 1 in that dimension."""
+        idi = ImageDataInterface(tmp_n5)
+        # IDI voxel_size is now (131, 100, 100) in z,y,x; z-voxel = 131
+        roi = Roi(Coordinate(0, 0, 0), Coordinate(131, 1000, 1000))
+        result = idi.to_ndarray_ts(roi)
+        assert result.shape[0] == 1, (
+            f"Expected 1 voxel in z, got {result.shape[0]} (shape={result.shape})"
+        )
+
+    def test_single_voxel_roi_x_axis(self, tmp_n5):
+        """A 1-voxel-thick ROI in x should return shape 1 in that dimension."""
+        idi = ImageDataInterface(tmp_n5)
+        # x-voxel = 100
+        roi = Roi(Coordinate(0, 0, 0), Coordinate(1310, 1000, 100))
+        result = idi.to_ndarray_ts(roi)
+        assert result.shape[2] == 1, (
+            f"Expected 1 voxel in x, got {result.shape[2]} (shape={result.shape})"
+        )
+
+    def test_roi_beyond_dataset_returns_correct_axes(self, tmp_n5):
+        """A ROI fully outside the dataset should return zeros in z,y,x order."""
+        idi = ImageDataInterface(tmp_n5)
+        # ROI completely past the dataset end in z; should be 1 voxel in z
+        roi = Roi(
+            Coordinate(idi.roi.end[0], 0, 0),
+            Coordinate(131, 1000, 1000),
+        )
+        result = idi.to_ndarray_ts(roi)
+        assert result.shape[0] == 1, (
+            f"Expected 1 voxel in z (no-overlap path), got shape {result.shape}"
+        )
+        assert np.all(result == 0)
+
+    def test_full_dataset_no_roi(self, tmp_n5):
+        """Reading full dataset (roi=None) should return correct axis order."""
+        idi = ImageDataInterface(tmp_n5)
+        result = idi.to_ndarray_ts()
+        # N5 on-disk shape is (20,25,10) in x,y,z; IDI presents as (10,25,20) in z,y,x
+        assert result.shape == (10, 25, 20)
+
+    def test_full_roi_shape(self, tmp_n5):
+        """Full dataset ROI should return the correct array shape."""
+        idi = ImageDataInterface(tmp_n5)
+        result = idi.to_ndarray_ts(idi.roi)
+        # N5 on-disk shape is (20,25,10) in x,y,z; IDI presents as (10,25,20) in z,y,x
+        assert result.shape == (10, 25, 20)


### PR DESCRIPTION
## Summary

Three related fixes for bugs that surface when running `assign_to_organelles` on datasets with fractional voxel sizes or N5 format. Both real-world cases were failing:

- **jrc_fly-acc-calyx-1** (zarr, voxel 59.52nm): all nuclear pores assigned to `nuc 80`
- **jrc_hela-3** (N5, voxel 3.24nm): dask workers OOM-killed during `_process_n_nearest_block`

### Fixes

- **`assign_to_organelles`**: scale COMs by `voxel_size_scale_factor` before block assignment and coordinate math. The IDI stores `voxel_size`/`roi` in scaled units (for integer compatibility with funlib), but CSV COMs are in real nm, so the two coordinate spaces were being mixed. Distances are divided by `scale_factor` before writing to the output CSV.

- **`to_ndarray_tensorstore`**: apply `swap_axes` on the `roi=None` early-return path so full-dataset reads match the axis order of ROI-based reads (previously inconsistent).

- **`ImageDataInterface`**: for N5 datasets, reverse raw metadata from native x,y,z to z,y,x so the IDI presents a consistent convention with zarr and the rest of the codebase. Previously the IDI exposed N5 metadata in x,y,z while data came back (after `swap_axes`) in z,y,x, causing downstream code to look up wrong voxels and — in `_process_n_nearest_block` — to double padding indefinitely until workers OOM'd.

### Root causes

1. `scale_voxel_size_to_integers` scales fractional voxel sizes by an integer factor so funlib's `Coordinate` can hold them. Scaled units were used internally but external CSV COMs remained in real nm — a silent no-op when scale_factor=1 (integer voxels) but a large error otherwise.
2. The `roi=None` path bypassed `swap_axes`, giving different axis orders depending on whether you passed a ROI.
3. `read_raw_voxel_size` returns `pixelResolution` directly (x,y,z) for N5, but callers assumed z,y,x.

## Test plan

- [x] `pytest tests/` — all 194 tests pass
- [x] `tests/operations/test_assign_to_organelles.py` ground truth updated to use `original_voxel_size` (real nm) so it actually validates correct behavior
- [x] N5 anisotropic tests (`TestN5AnisotropicSwapAxes`) updated for the new z,y,x convention
