### PR TITLE
Fix split_dataset_path for nested .zarr/.n5 containers; bump to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cellmap-analyze"
-version = "0.2.1"
+version = "0.2.2"
 description = "Code to perform analysis on segmentations like those produced by CellMap"
 readme = "README.md"
 license-files = ["LICENSE"]

--- a/src/cellmap_analyze/util/io_util.py
+++ b/src/cellmap_analyze/util/io_util.py
@@ -98,7 +98,7 @@ def split_dataset_path(dataset_path, scale=None) -> tuple[str, str]:
         ".zarr" if dataset_path.rfind(".zarr") > dataset_path.rfind(".n5") else ".n5"
     )
 
-    filename, dataset = dataset_path.split(splitter)
+    filename, dataset = dataset_path.rsplit(splitter, 1)
 
     # include scale if present
     if scale is not None:


### PR DESCRIPTION
## Summary
- Fix `split_dataset_path` to use `rsplit(splitter, 1)` so paths with nested `.zarr`/`.n5` segments (e.g. `foo.zarr/bar.zarr/multiscale/s0`) are split at the last occurrence rather than failing with `ValueError: too many values to unpack (expected 2)`.
- Bump version to 0.2.2 so the fix lands on PyPI.