### PR TITLE
Sharded skeleton output, seed-voxel fallback, OOM retries

### DIFF
--- a/src/cellmap_analyze/analyze/assign_to_organelles.py
+++ b/src/cellmap_analyze/analyze/assign_to_organelles.py
@@ -16,6 +16,7 @@ import logging
 import pandas as pd
 import numpy as np
 import os
+import shutil
 from scipy import spatial
 import fastremap
 import fastmorph
@@ -333,7 +334,7 @@ class AssignToOrganelles(ComputeConfigMixin):
             df.at[row_idx, id_col] = org_id
         df[id_col] = df[id_col].astype(int)
 
-        os.remove(coms_path)
+        shutil.rmtree(os.path.dirname(coms_path), ignore_errors=True)
 
     def assign_to_n_nearest_organelles(self, df, n, organelle_name):
         coms = df[["COM Z (nm)", "COM Y (nm)", "COM X (nm)"]].to_numpy()
@@ -379,7 +380,7 @@ class AssignToOrganelles(ComputeConfigMixin):
             merge_info=(AssignToOrganelles._merge_dicts, output_dir),
         )
 
-        os.remove(coms_path)
+        shutil.rmtree(os.path.dirname(coms_path), ignore_errors=True)
 
         # Apply results to DataFrame
         id_col = f"{organelle_name} ID"

--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -350,6 +350,39 @@ class Skeletonize(ComputeConfigMixin):
             skel = skeletonize(data)
 
             if not np.any(skel):
+                # Lee's 3D thinning algorithm peels mirror-symmetrically and
+                # can wipe out compact/spherical/cuboidal objects entirely.
+                # When that happens but the (pre-erosion) EDT still has signal,
+                # fall back to a single seed vertex at the EDT peak (the
+                # most-interior voxel). The object then gets a meaningful
+                # position and a radius equal to the local half-thickness,
+                # even though longest_shortest_path stays 0 (single point).
+                peak_idx = np.unravel_index(
+                    int(np.argmax(distance_transform)), distance_transform.shape
+                )
+                peak_radius_nm = float(distance_transform[peak_idx])
+                if peak_radius_nm > 0:
+                    logger.warning(
+                        f"Skeletonization produced no voxels for ID {id_value}, "
+                        f"emitting single seed vertex at EDT peak (radius={peak_radius_nm:.1f} nm)"
+                    )
+                    local_zyx_nm = np.array(peak_idx) * isotropic_voxel_size
+                    start_point_nm = np.array(start_point) / sf
+                    seed_vertex = (
+                        float(local_zyx_nm[2] + start_point_nm[2]),
+                        float(local_zyx_nm[1] + start_point_nm[1]),
+                        float(local_zyx_nm[0] + start_point_nm[0]),
+                    )
+                    seed_skel = CustomSkeleton(
+                        vertices=[seed_vertex],
+                        edges=np.zeros((0, 2), dtype=np.uint32),
+                    )
+                    emit("full", seed_skel)
+                    emit("simplified", seed_skel)
+                    result["radius_mean_nm"] = peak_radius_nm
+                    result["radius_std_nm"] = 0.0
+                    return result
+
                 logger.warning(
                     f"Skeletonization produced no voxels for ID {id_value}, emitting empty skeleton"
                 )

--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -11,6 +11,7 @@ from cellmap_analyze.util.skeleton_util import (
 )
 from scipy.ndimage import zoom
 from skimage.morphology import skeletonize, binary_erosion
+from tqdm import tqdm
 import logging
 import os
 import json
@@ -156,6 +157,9 @@ class Skeletonize(ComputeConfigMixin):
         tolerance_nm=50,
         num_workers=10,
         timeout=5,
+        sharded=True,
+        shard_bits=1,
+        minishard_bits=6,
     ):
         """
         Skeletonize a segmentation, parallelized over IDs.
@@ -175,6 +179,13 @@ class Skeletonize(ComputeConfigMixin):
             tolerance_nm: Tolerance for simplification (in nm)
             num_workers: Number of parallel workers
             timeout: Timeout for ImageDataInterface reads
+            sharded: Write outputs as neuroglancer_uint64_sharded_v1 instead of
+                     one file per ID. Workers still write per-ID files during
+                     the dask phase; the driver repacks them into shards at the
+                     end and deletes the originals.
+            shard_bits, minishard_bits: Sharding spec parameters; defaults give
+                     2 shard files × 64 minishards. Identity hash with
+                     preshift_bits=0 (good fit for densely-numbered MWS IDs).
         """
         super().__init__(num_workers)
         self.segmentation_idi = ImageDataInterface(segmentation_path, timeout=timeout)
@@ -197,6 +208,9 @@ class Skeletonize(ComputeConfigMixin):
         self.min_branch_length_nm = min_branch_length_nm
         self.tolerance_nm = tolerance_nm
         self.num_workers = num_workers
+        self.sharded = sharded
+        self.shard_bits = shard_bits
+        self.minishard_bits = minishard_bits
 
         # Load CSV with bounding box info
         self.bbox_df = pd.read_csv(csv_path, index_col=0)
@@ -230,20 +244,35 @@ class Skeletonize(ComputeConfigMixin):
         erosion: str,
         min_branch_length_nm: float,
         tolerance_nm: float,
+        sharded: bool = False,
     ):
         """
-        Process a single ID: extract, skeletonize, prune, simplify, and save.
+        Process a single ID: extract, skeletonize, prune, simplify, and emit.
 
-        Args:
-            id_value: The ID to process
-            segmentation_idi: ImageDataInterface for the segmentation
-            bbox_df: DataFrame with bounding box information
-            output_path: Base output path
-            erosion: Erosion mode ("full", "6", "18", or None)
-            min_branch_length_nm: Minimum branch length for pruning
-            tolerance_nm: Tolerance for simplification
+        When ``sharded=True``, encoded skeleton bytes are returned in the
+        result dict under ``"full_bytes"``/``"simplified_bytes"`` so the
+        driver can pack them into shard files via the existing pickle merge
+        path — no per-ID NRS write happens. When ``sharded=False``, per-ID
+        files are written under ``{output_path}/{full,simplified}/{id}``.
         """
         from funlib.geometry import Roi
+
+        result: dict = dict(Skeletonize._empty_metrics())
+
+        def emit(subdir: str, skel_obj: CustomSkeleton):
+            encoded = skel_obj.encode_neuroglancer_bytes()
+            if sharded:
+                result[f"{subdir}_bytes"] = encoded
+            else:
+                path = f"{output_path}/{subdir}/{id_value}"
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "wb") as f:
+                    f.write(encoded)
+
+        def emit_empty():
+            empty = CustomSkeleton(vertices=[], edges=[])
+            emit("full", empty)
+            emit("simplified", empty)
 
         try:
             # Get bounding box for this ID
@@ -272,8 +301,9 @@ class Skeletonize(ComputeConfigMixin):
 
             # Check if there's any data
             if not np.any(data):
-                logger.warning(f"No voxels found for ID {id_value}, skipping")
-                return Skeletonize._empty_metrics()
+                logger.warning(f"No voxels found for ID {id_value}, emitting empty skeleton")
+                emit_empty()
+                return result
 
             # Resample to isotropic if needed so skeletonize thins uniformly
             # Use original (true nm) voxel_size for physical operations
@@ -307,39 +337,24 @@ class Skeletonize(ComputeConfigMixin):
             elif erosion == "18":
                 data = remove_unbridged_adjacencies(data, connectivity=18)
 
-            if erosion is not None:
-                # Check if erosion removed everything
-                if not np.any(data):
-                    logger.warning(
-                        f"Erosion removed all voxels for ID {id_value}, writing empty skeleton"
-                    )
-                    # Write empty skeleton files
-                    empty_skeleton = CustomSkeleton(vertices=[], edges=[])
-                    full_path = f"{output_path}/full/{id_value}"
-                    empty_skeleton.write_neuroglancer_skeleton(full_path)
-                    simplified_path = f"{output_path}/simplified/{id_value}"
-                    empty_skeleton.write_neuroglancer_skeleton(simplified_path)
-                    logger.info(f"Wrote empty skeleton for ID {id_value}")
-                    return Skeletonize._empty_metrics()
+            if erosion is not None and not np.any(data):
+                logger.warning(
+                    f"Erosion removed all voxels for ID {id_value}, emitting empty skeleton"
+                )
+                emit_empty()
+                return result
 
             # Skeletonize using Lee's algorithm (skimage default). It has
             # known limitations (e.g. thin structures may lose branches) but
             # is sufficient for now.
             skel = skeletonize(data)
 
-            # Check if skeletonization produced anything
             if not np.any(skel):
                 logger.warning(
-                    f"Skeletonization produced no voxels for ID {id_value}, writing empty skeleton"
+                    f"Skeletonization produced no voxels for ID {id_value}, emitting empty skeleton"
                 )
-                # Write empty skeleton files
-                empty_skeleton = CustomSkeleton(vertices=[], edges=[])
-                full_path = f"{output_path}/full/{id_value}"
-                empty_skeleton.write_neuroglancer_skeleton(full_path)
-                simplified_path = f"{output_path}/simplified/{id_value}"
-                empty_skeleton.write_neuroglancer_skeleton(simplified_path)
-                logger.info(f"Wrote empty skeleton for ID {id_value}")
-                return Skeletonize._empty_metrics()
+                emit_empty()
+                return result
 
             # Sample radii at skeleton voxel positions
             skel_coords = np.argwhere(skel)
@@ -402,12 +417,10 @@ class Skeletonize(ComputeConfigMixin):
                         longest_shortest_path, component_diameter
                     )
 
-            skeleton_metrics = {
-                "longest_shortest_path_nm": longest_shortest_path,
-                "num_branches": num_branches,
-                "radius_mean_nm": float(np.mean(radii)),
-                "radius_std_nm": float(np.std(radii)),
-            }
+            result["longest_shortest_path_nm"] = longest_shortest_path
+            result["num_branches"] = num_branches
+            result["radius_mean_nm"] = float(np.mean(radii))
+            result["radius_std_nm"] = float(np.std(radii))
 
             # Simplify
             if tolerance_nm > 0:
@@ -415,22 +428,15 @@ class Skeletonize(ComputeConfigMixin):
             else:
                 simplified = pruned
 
-            # Check if pruning/simplification removed all vertices
             if len(simplified.vertices) == 0:
                 logger.warning(
-                    f"Pruning/simplification removed all vertices for ID {id_value}, writing empty skeleton"
+                    f"Pruning/simplification removed all vertices for ID {id_value}, emitting empty skeleton"
                 )
-                # Write empty skeleton files
-                empty_skeleton = CustomSkeleton(vertices=[], edges=[])
-                full_path = f"{output_path}/full/{id_value}"
-                empty_skeleton.write_neuroglancer_skeleton(full_path)
-                simplified_path = f"{output_path}/simplified/{id_value}"
-                empty_skeleton.write_neuroglancer_skeleton(simplified_path)
-                logger.info(f"Wrote empty skeleton for ID {id_value}")
-                return Skeletonize._empty_metrics()
+                emit_empty()
+                return result
 
-            # Ensure edges are properly shaped numpy arrays before writing
-            # Handle case where there are no edges (single vertex)
+            # Ensure edges are properly shaped numpy arrays before encoding
+            # (single vertex / empty edges case).
             if len(skeleton.edges) == 0:
                 skeleton.edges = np.zeros((0, 2), dtype=np.uint32)
             else:
@@ -441,21 +447,9 @@ class Skeletonize(ComputeConfigMixin):
             else:
                 simplified.edges = np.array(simplified.edges, dtype=np.uint32)
 
-            # Write full skeleton
-            full_path = f"{output_path}/full/{id_value}"
-            skeleton.write_neuroglancer_skeleton(full_path)
-            logger.info(
-                f"Wrote full skeleton for ID {id_value}: {len(skeleton.vertices)} vertices"
-            )
-
-            # Write simplified skeleton
-            simplified_path = f"{output_path}/simplified/{id_value}"
-            simplified.write_neuroglancer_skeleton(simplified_path)
-            logger.info(
-                f"Wrote simplified skeleton for ID {id_value}: {len(simplified.vertices)} vertices"
-            )
-
-            return skeleton_metrics
+            emit("full", skeleton)
+            emit("simplified", simplified)
+            return result
 
         except Exception as e:
             logger.error(f"Error processing ID {id_value}: {e}", exc_info=True)
@@ -486,6 +480,12 @@ class Skeletonize(ComputeConfigMixin):
                 ],  # Identity transform since we're using physical coordinates
                 "segment_properties": "segment_properties",
             }
+
+            if self.sharded:
+                from cellmap_analyze.util.sharded_skeleton import make_sharding_spec
+                info["sharding"] = make_sharding_spec(
+                    shard_bits=self.shard_bits, minishard_bits=self.minishard_bits
+                )
 
             info_path = f"{self.output_path}/{subdir}/info"
             with open(info_path, "w") as f:
@@ -540,9 +540,66 @@ class Skeletonize(ComputeConfigMixin):
             merge_info=(Skeletonize._merge_skeleton_metrics, tmp_merge_dir),
         )
 
+        # When sharded, workers piggybacked encoded skeleton bytes onto each
+        # metrics dict via the pickle merge — no per-ID files were written.
+        # Pop the bytes out (so they don't end up in the CSV) and write shards.
+        if self.sharded:
+            self._pack_shards_from_metrics(skeleton_metrics)
+
         self._write_skeleton_csv(skeleton_metrics)
 
         logger.info("Skeletonization complete")
+
+    def _pack_shards_from_metrics(self, metrics_list):
+        """Pack encoded skeleton bytes (already in memory via pickle merge)
+        into precomputed sharded shard files.
+
+        Pops ``full_bytes``/``simplified_bytes`` from each metric dict in
+        ``metrics_list`` so subsequent CSV writing sees only metric columns.
+        No NRS read/unlink work — the bytes were carried back on the dask
+        merge path that runs for every job regardless.
+        """
+        import time
+        from cellmap_analyze.util.sharded_skeleton import pack_sharded_skeletons
+
+        for subdir, bytes_key in [("full", "full_bytes"), ("simplified", "simplified_bytes")]:
+            dir_path = f"{self.output_path}/{subdir}"
+
+            t0 = time.time()
+            id_to_bytes: dict[int, bytes] = {}
+            iterator = tqdm(
+                metrics_list,
+                desc=f"Gathering {subdir} skeleton bytes",
+                unit="id",
+            )
+            for m in iterator:
+                data = m.pop(bytes_key, None)
+                if data is None:
+                    continue
+                id_to_bytes[int(m["id"])] = data
+            logger.info(
+                f"Gathered {len(id_to_bytes)} {subdir} skeletons in "
+                f"{time.time() - t0:.1f}s"
+            )
+
+            if not id_to_bytes:
+                logger.warning(
+                    f"No {subdir} skeleton bytes found in metrics; skipping shard pack"
+                )
+                continue
+
+            t0 = time.time()
+            pack_sharded_skeletons(
+                id_to_bytes,
+                dir_path,
+                shard_bits=self.shard_bits,
+                minishard_bits=self.minishard_bits,
+            )
+            logger.info(
+                f"Packed {len(id_to_bytes)} {subdir} skeletons into shards under "
+                f"{dir_path} in {time.time() - t0:.1f}s"
+            )
+            del id_to_bytes
 
     @staticmethod
     def _merge_skeleton_metrics(list_of_results):
@@ -586,6 +643,7 @@ class Skeletonize(ComputeConfigMixin):
             self.erosion,
             self.min_branch_length_nm,
             self.tolerance_nm,
+            sharded=self.sharded,
         )
         if result is None:
             result = Skeletonize._empty_metrics()

--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -160,6 +160,8 @@ class Skeletonize(ComputeConfigMixin):
         sharded=True,
         shard_bits=1,
         minishard_bits=6,
+        retry_on_oom=True,
+        memory_retry_max=3,
     ):
         """
         Skeletonize a segmentation, parallelized over IDs.
@@ -186,6 +188,8 @@ class Skeletonize(ComputeConfigMixin):
             shard_bits, minishard_bits: Sharding spec parameters; defaults give
                      2 shard files × 64 minishards. Identity hash with
                      preshift_bits=0 (good fit for densely-numbered MWS IDs).
+            retry_on_oom: Halve processes-per-slot and retry on worker OOM.
+            memory_retry_max: Max OOM-driven retries before raising.
         """
         super().__init__(num_workers)
         self.segmentation_idi = ImageDataInterface(segmentation_path, timeout=timeout)
@@ -211,6 +215,8 @@ class Skeletonize(ComputeConfigMixin):
         self.sharded = sharded
         self.shard_bits = shard_bits
         self.minishard_bits = minishard_bits
+        self.retry_on_oom = retry_on_oom
+        self.memory_retry_max = memory_retry_max
 
         # Load CSV with bounding box info
         self.bbox_df = pd.read_csv(csv_path, index_col=0)
@@ -559,18 +565,30 @@ class Skeletonize(ComputeConfigMixin):
         # First write the info files (only once)
         self.write_neuroglancer_info_files()
 
-        # Parallelize over IDs using dask
+        # Parallelize over IDs using dask, with OOM-driven backoff.
         num_ids = len(self.ids)
         tmp_merge_dir = f"{self.output_path}/_tmp_skeleton_metrics_to_merge"
+        msg = f"skeletonizing {num_ids} IDs from {self.segmentation_idi.path}"
 
-        skeleton_metrics = dask_util.compute_blockwise_partitions(
-            num_ids,
+        def _phase(workers, config):
+            return dask_util.compute_blockwise_partitions(
+                num_ids,
+                workers,
+                self.compute_args,
+                logger,
+                msg,
+                self._skeletonize_id_wrapper,
+                merge_info=(Skeletonize._merge_skeleton_metrics, tmp_merge_dir),
+                config=config,
+            )
+
+        skeleton_metrics = dask_util.run_with_oom_retry(
+            _phase,
             self.num_workers,
-            self.compute_args,
+            "skeletonize",
             logger,
-            f"skeletonizing {num_ids} IDs from {self.segmentation_idi.path}",
-            self._skeletonize_id_wrapper,
-            merge_info=(Skeletonize._merge_skeleton_metrics, tmp_merge_dir),
+            max_retries=self.memory_retry_max,
+            retry_on_oom=self.retry_on_oom,
         )
 
         # When sharded, workers piggybacked encoded skeleton bytes onto each

--- a/src/cellmap_analyze/util/dask_util.py
+++ b/src/cellmap_analyze/util/dask_util.py
@@ -354,6 +354,78 @@ def start_dask(num_workers=1, msg="processing", logger=None, config=None):
         client.close()
 
 
+def run_with_oom_retry(
+    work_fn,
+    num_workers,
+    phase_name,
+    logger,
+    max_retries=3,
+    retry_on_oom=True,
+):
+    """Run a dask phase, halving processes-per-slot and retrying on worker OOM.
+
+    Ported from mesh-n-bone. ``work_fn`` is called as ``work_fn(workers, config)``
+    and must start its own cluster via ``start_dask(workers, ..., config=config)``.
+    On ``distributed.scheduler.KilledWorker`` (the typical symptom of a SIGKILL
+    from the OS OOM-killer or LSF mem limit), we halve ``processes`` per slot in
+    the in-memory dask config and halve ``num_workers`` to match — doubling the
+    memory per worker while keeping total slot/CPU budget constant — then retry.
+
+    No-ops (passes through) for synchronous (num_workers <= 1) runs, when
+    ``retry_on_oom=False``, when ``max_retries < 1``, or for cluster types that
+    don't expose a processes-per-slot lever (e.g. local).
+    """
+    if not retry_on_oom or max_retries < 1 or num_workers <= 1:
+        return work_fn(num_workers, None)
+
+    try:
+        from distributed.scheduler import KilledWorker
+    except ImportError:
+        return work_fn(num_workers, None)
+
+    with open("dask-config.yaml") as f:
+        config = yaml.load(f, Loader=SafeLoader)
+
+    cluster_type = next(iter(config.get("jobqueue", {})), None)
+    if cluster_type not in ("lsf", "slurm", "sge"):
+        return work_fn(num_workers, config)
+
+    workers = num_workers
+    for attempt in range(max_retries + 1):
+        try:
+            return work_fn(workers, config)
+        except KilledWorker as e:
+            processes = int(config["jobqueue"][cluster_type].get("processes", 1) or 1)
+            if attempt >= max_retries:
+                logger.error(
+                    "Phase '%s' hit worker OOM and exhausted %d retries "
+                    "(processes/slot=%d). Increase per-slot memory in "
+                    "dask-config.yaml.",
+                    phase_name, max_retries, processes,
+                )
+                raise
+            if processes <= 1:
+                logger.error(
+                    "Phase '%s' hit worker OOM with processes/slot already at "
+                    "1 — cannot halve further. Increase memory per slot directly.",
+                    phase_name,
+                )
+                raise
+            new_processes = max(1, processes // 2)
+            new_workers = max(1, workers // 2)
+            last_worker = getattr(e, "last_worker", None)
+            logger.warning(
+                "Phase '%s' worker OOM (retry %d/%d). Halving processes/slot "
+                "%d→%d and workers %d→%d to double memory per worker. "
+                "Last worker: %s",
+                phase_name, attempt + 1, max_retries,
+                processes, new_processes, workers, new_workers,
+                last_worker or "(unknown)",
+            )
+            config["jobqueue"][cluster_type]["processes"] = new_processes
+            workers = new_workers
+
+
 def setup_execution_directory(config_path, logger):
     """Sets up the excecution directory which is the config dir appended with
     the date and time.
@@ -531,6 +603,7 @@ def compute_blockwise_partitions(
     *fn_args,
     randomize: bool = False,
     merge_info=None,
+    config: dict | None = None,
     **fn_kwargs,
 ):
     """
@@ -560,7 +633,7 @@ def compute_blockwise_partitions(
         )
 
     # STEP 3) Spin up Dask, run
-    with start_dask(num_workers, msg, logger):
+    with start_dask(num_workers, msg, logger, config=config):
         with TimingMessager(msg.capitalize(), logger):
             try:
                 bag.compute(**compute_args)

--- a/src/cellmap_analyze/util/sharded_skeleton.py
+++ b/src/cellmap_analyze/util/sharded_skeleton.py
@@ -1,0 +1,214 @@
+"""Hand-rolled writer for the neuroglancer_uint64_sharded_v1 skeleton format.
+
+Spec reference:
+https://github.com/google/neuroglancer/blob/master/src/datasource/precomputed/sharded.md
+
+Only the subset we need is supported: identity hash, raw data/index encoding.
+Reading is left to neuroglancer; this module only packs already-encoded
+per-ID skeleton bytes into shard files plus the sharding spec for the info file.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import struct
+from typing import Iterable
+
+
+SHARDING_TYPE = "neuroglancer_uint64_sharded_v1"
+
+
+def make_sharding_spec(
+    preshift_bits: int = 0, shard_bits: int = 1, minishard_bits: int = 6
+) -> dict:
+    """Return the sharding spec dict for an ``info`` file. The same
+    parameters must be passed to :func:`pack_sharded_skeletons` so the
+    written shards match what readers expect.
+    """
+    return {
+        "@type": SHARDING_TYPE,
+        "preshift_bits": preshift_bits,
+        "hash": "identity",
+        "minishard_bits": minishard_bits,
+        "shard_bits": shard_bits,
+        "minishard_index_encoding": "raw",
+        "data_encoding": "raw",
+    }
+
+
+def _assign_bucket(
+    object_id: int, preshift_bits: int, shard_bits: int, minishard_bits: int
+) -> tuple[int, int]:
+    """Map a chunk ID to (shard_no, minishard_no) per the sharded v1 spec.
+
+    With hash="identity":
+        hashed = object_id >> preshift_bits
+        minishard = hashed & ((1 << minishard_bits) - 1)
+        shard     = (hashed >> minishard_bits) & ((1 << shard_bits) - 1)
+    """
+    hashed = object_id >> preshift_bits
+    minishard = hashed & ((1 << minishard_bits) - 1)
+    shard = (hashed >> minishard_bits) & ((1 << shard_bits) - 1)
+    return shard, minishard
+
+
+def _shard_filename(shard_no: int, shard_bits: int) -> str:
+    # Spec: lowercase hex, zero-padded to ceil(shard_bits/4) digits. We refuse
+    # shard_bits=0 in pack_sharded_skeletons so this is always >=1, matching
+    # the spec exactly and avoiding the POSIX-hidden ".shard" filename.
+    digits = math.ceil(shard_bits / 4)
+    return f"{shard_no:0{digits}x}.shard"
+
+
+def _pack_minishard(
+    chunks: list[tuple[int, bytes]], cursor: int
+) -> tuple[bytes, bytes, int]:
+    """Build the data blob + minishard index for a sorted list of chunks.
+
+    Returns (data_blob, index_blob, new_cursor). All offsets in the index are
+    relative to the end of the shard index (i.e., the same "post-shard-index"
+    coordinate system in which `cursor` lives).
+    """
+    n = len(chunks)
+    ids = [c[0] for c in chunks]
+    sizes = [len(c[1]) for c in chunks]
+
+    # array[0] — chunk IDs, delta-encoded: first is absolute, rest are diffs.
+    id_deltas = [ids[0]] + [ids[i] - ids[i - 1] for i in range(1, n)]
+
+    # array[1] — chunk start offsets, delta-encoded relative to *end of previous chunk*.
+    # First is absolute (cursor at start of this minishard's data).
+    # We pack chunks contiguously, so deltas for i>=1 are all zero.
+    offset_deltas = [cursor] + [0] * (n - 1)
+
+    # array[2] — chunk sizes, literal.
+    minishard_index = struct.pack(
+        f"<{3 * n}Q", *id_deltas, *offset_deltas, *sizes
+    )
+
+    data_blob = b"".join(c[1] for c in chunks)
+    new_cursor = cursor + len(data_blob) + len(minishard_index)
+    return data_blob, minishard_index, new_cursor
+
+
+def pack_sharded_skeletons(
+    id_to_bytes: dict[int, bytes],
+    output_dir: str,
+    preshift_bits: int = 0,
+    shard_bits: int = 1,
+    minishard_bits: int = 6,
+) -> dict:
+    """Pack ID→skeleton-bytes into precomputed sharded v1 shard files.
+
+    Writes ``<output_dir>/<shard_hex>.shard`` files. Returns the sharding spec
+    dict to embed under the "sharding" key in the ``info`` file.
+
+    Only ``hash="identity"`` and raw (uncompressed) encoding are supported;
+    MWS-style densely-numbered uint64 IDs spread evenly under identity hashing.
+    """
+    if shard_bits < 1:
+        raise ValueError(
+            "shard_bits must be >= 1; shard_bits=0 would emit a hidden "
+            "'.shard' file per the spec, which is fragile on POSIX."
+        )
+    if minishard_bits < 0:
+        raise ValueError("minishard_bits must be >= 0")
+    os.makedirs(output_dir, exist_ok=True)
+    n_minishards_per_shard = 1 << minishard_bits
+    n_shards = 1 << shard_bits
+
+    # Bucket per (shard, minishard).
+    buckets: dict[tuple[int, int], list[tuple[int, bytes]]] = {}
+    for obj_id, data in id_to_bytes.items():
+        s, m = _assign_bucket(int(obj_id), preshift_bits, shard_bits, minishard_bits)
+        buckets.setdefault((s, m), []).append((int(obj_id), data))
+
+    for shard_no in range(n_shards):
+        # For each minishard slot, build its (data, index) bytes and track
+        # the start/end offsets of its index relative to end-of-shard-index.
+        shard_index_entries: list[tuple[int, int]] = []  # (start, end) per minishard
+        body_parts: list[bytes] = []
+        cursor = 0  # bytes written after the shard index header
+
+        for mini_no in range(n_minishards_per_shard):
+            chunks = sorted(buckets.get((shard_no, mini_no), []), key=lambda c: c[0])
+            if not chunks:
+                # Empty minishard: zero-length index at the current cursor.
+                shard_index_entries.append((cursor, cursor))
+                continue
+
+            data_blob, index_blob, new_cursor = _pack_minishard(chunks, cursor)
+            body_parts.append(data_blob)
+            data_end = cursor + len(data_blob)
+            shard_index_entries.append((data_end, data_end + len(index_blob)))
+            body_parts.append(index_blob)
+            cursor = new_cursor
+
+        shard_index_buf = b"".join(
+            struct.pack("<QQ", s, e) for s, e in shard_index_entries
+        )
+        shard_path = os.path.join(output_dir, _shard_filename(shard_no, shard_bits))
+        with open(shard_path, "wb") as f:
+            f.write(shard_index_buf)
+            for part in body_parts:
+                f.write(part)
+
+    return make_sharding_spec(preshift_bits, shard_bits, minishard_bits)
+
+
+def read_chunk_from_shard(
+    shard_dir: str,
+    object_id: int,
+    sharding: dict,
+) -> bytes | None:
+    """Read a single chunk back out of the shard files. Used for tests.
+
+    Returns the chunk bytes, or None if the chunk is absent.
+    """
+    preshift_bits = sharding["preshift_bits"]
+    shard_bits = sharding["shard_bits"]
+    minishard_bits = sharding["minishard_bits"]
+    if sharding.get("hash", "identity") != "identity":
+        raise NotImplementedError("Only identity hashing is supported")
+    if sharding.get("data_encoding", "raw") != "raw":
+        raise NotImplementedError("Only raw data_encoding is supported")
+    if sharding.get("minishard_index_encoding", "raw") != "raw":
+        raise NotImplementedError("Only raw minishard_index_encoding is supported")
+
+    shard_no, mini_no = _assign_bucket(
+        int(object_id), preshift_bits, shard_bits, minishard_bits
+    )
+    shard_path = os.path.join(shard_dir, _shard_filename(shard_no, shard_bits))
+    if not os.path.exists(shard_path):
+        return None
+
+    n_minishards = 1 << minishard_bits
+    shard_index_size = 16 * n_minishards
+    with open(shard_path, "rb") as f:
+        header = f.read(shard_index_size)
+        start, end = struct.unpack_from("<QQ", header, mini_no * 16)
+        if end <= start:
+            return None
+        f.seek(shard_index_size + start)
+        raw = f.read(end - start)
+        n = (end - start) // 24
+        triples = struct.unpack(f"<{3 * n}Q", raw)
+        id_deltas = triples[0:n]
+        offset_deltas = triples[n : 2 * n]
+        sizes = triples[2 * n : 3 * n]
+
+        ids = []
+        last = 0
+        for d in id_deltas:
+            last += d
+            ids.append(last)
+
+        # offset[i] = shard_index_end + sum(offset_deltas[0..i]) + sum(sizes[0..i-1])
+        target = int(object_id)
+        if target not in ids:
+            return None
+        i = ids.index(target)
+        offset = shard_index_size + sum(offset_deltas[: i + 1]) + sum(sizes[:i])
+        f.seek(offset)
+        return f.read(sizes[i])

--- a/src/cellmap_analyze/util/skeleton_util.py
+++ b/src/cellmap_analyze/util/skeleton_util.py
@@ -879,43 +879,37 @@ class CustomSkeleton:
         # use hypot for Pythagoras to improve accuracy
         return np.hypot(h, c)
 
-    def write_neuroglancer_skeleton(self, path):
-        start_time = time.time()
-        logger.info(f"Writing Neuroglancer skeleton to {path}")
+    def encode_neuroglancer_bytes(self) -> bytes:
+        """Return the bytes that would be written to disk by
+        write_neuroglancer_skeleton, without touching the filesystem.
 
-        makedirs_start = time.time()
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        logger.info(f"Created directory in {time.time() - makedirs_start:.4f}s")
+        Empty skeletons are encoded as 8 bytes (two zero uint32s), matching
+        the on-disk format used by neuroglancer for an empty chunk.
+        """
+        import struct
 
-        # Handle empty skeleton specially (neuroglancer library doesn't support empty arrays)
         if len(self.vertices) == 0:
-            import struct
-            with open(path, "wb") as f:
-                # Write num_vertices (uint32) and num_edges (uint32), both 0
-                f.write(struct.pack('<II', 0, 0))
-            logger.info(f"Wrote empty skeleton (8 bytes)")
-            logger.info(
-                f"Total write_neuroglancer_skeleton time: {time.time() - start_time:.4f}s"
-            )
-            return
+            return struct.pack("<II", 0, 0)
 
-        encode_start = time.time()
-        with open(path, "wb") as f:
-            skel = NeuroglancerSkeleton(
-                self.vertices, self.edges, vertex_attributes=None
-            )
-            encoded = skel.encode(Source())
-            logger.info(f"Encoded skeleton in {time.time() - encode_start:.4f}s")
+        # neuroglancer requires edges as an ndarray of shape (N, 2).
+        # CustomSkeleton.add_edges() turns the input into a Python list, so
+        # coerce here to protect single-vertex / zero-edge cases (seed-voxel
+        # fallback, etc.).
+        if len(self.edges) == 0:
+            edges = np.zeros((0, 2), dtype=np.uint32)
+        else:
+            edges = np.asarray(self.edges, dtype=np.uint32)
 
-            write_start = time.time()
-            f.write(encoded)
-            logger.info(
-                f"Wrote {len(encoded)} bytes in {time.time() - write_start:.4f}s"
-            )
-
-        logger.info(
-            f"Total write_neuroglancer_skeleton time: {time.time() - start_time:.4f}s"
+        skel = NeuroglancerSkeleton(
+            self.vertices, edges, vertex_attributes=None
         )
+        return skel.encode(Source())
+
+    def write_neuroglancer_skeleton(self, path):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        encoded = self.encode_neuroglancer_bytes()
+        with open(path, "wb") as f:
+            f.write(encoded)
 
     @staticmethod
     def read_neuroglancer_skeleton(path):

--- a/tests/operations/test_skeletonize.py
+++ b/tests/operations/test_skeletonize.py
@@ -154,6 +154,7 @@ def test_skeletonize_single_worker(tmp_zarr, tmp_skeletonize_csv):
         min_branch_length_nm=0,  # No pruning for basic test
         tolerance_nm=0,  # No simplification for basic test
         num_workers=1,
+        sharded=False,
     )
 
     skeletonizer.skeletonize()
@@ -208,6 +209,7 @@ def test_skeletonize_produces_reasonable_skeletons(
         min_branch_length_nm=0,
         tolerance_nm=0,
         num_workers=1,
+        sharded=False,
     )
 
     skeletonizer.skeletonize()
@@ -286,6 +288,7 @@ def test_skeletonize_without_erosion(tmp_zarr, tmp_skeletonize_csv, voxel_size):
         min_branch_length_nm=0,
         tolerance_nm=0,
         num_workers=1,
+        sharded=False,
     )
 
     skeletonizer.skeletonize()
@@ -370,6 +373,7 @@ def test_skeletonize_with_pruning_and_simplification(tmp_zarr, tmp_skeletonize_c
         min_branch_length_nm=0,
         tolerance_nm=0,
         num_workers=1,
+        sharded=False,
     )
     skeletonizer_full.skeletonize()
 
@@ -382,6 +386,7 @@ def test_skeletonize_with_pruning_and_simplification(tmp_zarr, tmp_skeletonize_c
         min_branch_length_nm=min_branch_length_nm,
         tolerance_nm=tolerance_nm,
         num_workers=1,
+        sharded=False,
     )
     skeletonizer_simplified.skeletonize()
 
@@ -421,6 +426,7 @@ def test_skeletonize_with_roi_padding(tmp_zarr, tmp_skeletonize_csv, voxel_size)
         min_branch_length_nm=0,
         tolerance_nm=0,
         num_workers=1,
+        sharded=False,
     )
 
     skeletonizer.skeletonize()
@@ -492,6 +498,7 @@ def test_skeletonize_complex_shapes(tmp_zarr, tmp_skeletonize_csv, voxel_size):
         min_branch_length_nm=0,
         tolerance_nm=0,
         num_workers=1,
+        sharded=False,
     )
 
     skeletonizer.skeletonize()
@@ -561,6 +568,7 @@ def test_skeletonize_preserves_loops(tmp_zarr, tmp_skeletonize_csv, voxel_size):
         min_branch_length_nm=0,
         tolerance_nm=5,
         num_workers=1,
+        sharded=False,
     )
 
     skeletonizer.skeletonize()
@@ -748,6 +756,7 @@ def test_skeletonize_diagonal_6_erosion(tmp_zarr, tmp_skeletonize_csv):
         min_branch_length_nm=0,
         tolerance_nm=0,
         num_workers=1,
+        sharded=False,
     )
 
     skeletonizer.skeletonize()
@@ -772,6 +781,7 @@ def test_skeletonize_diagonal_18_erosion(tmp_zarr, tmp_skeletonize_csv):
         min_branch_length_nm=0,
         tolerance_nm=0,
         num_workers=1,
+        sharded=False,
     )
 
     skeletonizer.skeletonize()
@@ -796,6 +806,7 @@ def test_skeletonize_backward_compat_erosion_true(tmp_zarr, tmp_skeletonize_csv)
         min_branch_length_nm=0,
         tolerance_nm=0,
         num_workers=1,
+        sharded=False,
     )
 
     assert skeletonizer.erosion == "full"
@@ -803,6 +814,53 @@ def test_skeletonize_backward_compat_erosion_true(tmp_zarr, tmp_skeletonize_csv)
 
     for id_val in [1, 2, 3, 4, 5, 6, 7, 8]:
         assert os.path.exists(f"{output_path}/full/{id_val}")
+
+
+def test_skeletonize_sharded_default(tmp_zarr, tmp_skeletonize_csv):
+    """With sharded=True default, per-ID files are repacked into shard files
+    and the info file picks up the sharding spec; one chunk should round-trip
+    via the read helper."""
+    from cellmap_analyze.util.sharded_skeleton import read_chunk_from_shard
+
+    output_path = tmp_zarr + "/test_skeletonize_sharded"
+
+    skeletonizer = Skeletonize(
+        segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+        output_path=output_path,
+        csv_path=tmp_skeletonize_csv,
+        erosion=False,
+        min_branch_length_nm=0,
+        tolerance_nm=0,
+        num_workers=1,
+    )
+    skeletonizer.skeletonize()
+
+    for subdir in ["full", "simplified"]:
+        info_path = f"{output_path}/{subdir}/info"
+        with open(info_path) as f:
+            info = json.load(f)
+        assert "sharding" in info, f"Sharding spec missing from {info_path}"
+        assert info["sharding"]["@type"] == "neuroglancer_uint64_sharded_v1"
+
+        shard_files = [
+            n for n in os.listdir(f"{output_path}/{subdir}") if n.endswith(".shard")
+        ]
+        assert shard_files, f"No .shard files written under {subdir}/"
+
+        # Per-ID files should be gone.
+        for id_val in [1, 2, 3, 4, 5, 6, 7, 8]:
+            assert not os.path.exists(f"{output_path}/{subdir}/{id_val}")
+
+        # At least one non-empty chunk should round-trip out of the shards.
+        found_any = False
+        for id_val in [1, 2, 3, 4, 5, 6, 7, 8]:
+            chunk = read_chunk_from_shard(
+                f"{output_path}/{subdir}", id_val, info["sharding"]
+            )
+            if chunk:
+                found_any = True
+                break
+        assert found_any, f"No skeleton chunks readable from shards in {subdir}/"
 
 
 def test_skeletonize_backward_compat_erosion_false(tmp_zarr, tmp_skeletonize_csv):
@@ -817,6 +875,7 @@ def test_skeletonize_backward_compat_erosion_false(tmp_zarr, tmp_skeletonize_csv
         min_branch_length_nm=0,
         tolerance_nm=0,
         num_workers=1,
+        sharded=False,
     )
 
     assert skeletonizer.erosion is None

--- a/tests/operations/test_skeletonize.py
+++ b/tests/operations/test_skeletonize.py
@@ -816,6 +816,86 @@ def test_skeletonize_backward_compat_erosion_true(tmp_zarr, tmp_skeletonize_csv)
         assert os.path.exists(f"{output_path}/full/{id_val}")
 
 
+def test_skeletonize_seed_voxel_fallback(shared_tmpdir):
+    """A 4x4x4 cube is wiped to zero voxels by Lee's algorithm. The
+    seed-voxel fallback should emit a single-vertex skeleton at the EDT
+    peak with a positive radius, instead of writing an empty skeleton."""
+    from cellmap_analyze.util.zarr_util import create_multiscale_dataset
+    from funlib.geometry import Coordinate, Roi
+
+    # Build a tiny zarr with one 4x4x4 cube (ID=1) inside a 12x12x12 volume.
+    # Use isotropic 1nm voxels so we don't trigger resampling.
+    vs = (1, 1, 1)
+    seg = np.zeros((12, 12, 12), dtype=np.uint8)
+    seg[4:8, 4:8, 4:8] = 1
+
+    zarr_path = shared_tmpdir + "/seed_voxel_test.zarr"
+    os.makedirs(zarr_path, exist_ok=True)
+    data_path = f"{zarr_path}/seg_cube"
+    total_roi = Roi((0, 0, 0), Coordinate(seg.shape) * Coordinate(vs))
+    ds = create_multiscale_dataset(
+        data_path,
+        dtype=seg.dtype,
+        voxel_size=vs,
+        total_roi=total_roi,
+        write_size=Coordinate(seg.shape) * Coordinate(vs),
+        original_voxel_size=vs,
+    )
+    ds.data[:] = seg
+
+    # CSV with the one cube's bbox.
+    csv_path = shared_tmpdir + "/seed_voxel_bboxes.csv"
+    pd.DataFrame(
+        [{
+            "Object ID": 1,
+            "MIN X (nm)": 4.5,
+            "MIN Y (nm)": 4.5,
+            "MIN Z (nm)": 4.5,
+            "MAX X (nm)": 7.5,
+            "MAX Y (nm)": 7.5,
+            "MAX Z (nm)": 7.5,
+        }]
+    ).set_index("Object ID").to_csv(csv_path)
+
+    output_path = shared_tmpdir + "/seed_voxel_output"
+
+    Skeletonize(
+        segmentation_path=f"{data_path}/s0",
+        output_path=output_path,
+        csv_path=csv_path,
+        erosion=False,
+        min_branch_length_nm=0,
+        tolerance_nm=0,
+        num_workers=1,
+        sharded=False,
+    ).skeletonize()
+
+    # The fallback should have written a 1-vertex skeleton (not empty).
+    verts, edges = CustomSkeleton.read_neuroglancer_skeleton(f"{output_path}/full/1")
+    assert len(verts) == 1, f"expected 1 seed vertex, got {len(verts)}"
+    assert len(edges) == 0, f"expected 0 edges for single-vertex skeleton, got {len(edges)}"
+
+    # Seed should sit at the cube interior (somewhere in [4, 8] on every axis).
+    x, y, z = verts[0]
+    assert 4.0 <= x <= 8.0, f"seed x={x} outside cube"
+    assert 4.0 <= y <= 8.0, f"seed y={y} outside cube"
+    assert 4.0 <= z <= 8.0, f"seed z={z} outside cube"
+
+    # CSV: 0 length, 0 branches, but Radius Mean should be positive (~half-thickness).
+    csv_basename = os.path.splitext(os.path.basename(csv_path))[0]
+    metrics_csv = os.path.join(
+        os.path.dirname(csv_path), f"{csv_basename}_with_skeletons.csv"
+    )
+    df = pd.read_csv(metrics_csv, index_col=0)
+    assert df.loc[1, "Number of Branches"] == 0
+    assert df.loc[1, "Longest Shortest Path (nm)"] == 0.0
+    assert df.loc[1, "Radius Mean (nm)"] > 0, (
+        f"seed-voxel fallback should populate radius, got "
+        f"{df.loc[1, 'Radius Mean (nm)']!r}"
+    )
+    assert df.loc[1, "Radius Std (nm)"] == 0.0
+
+
 def test_skeletonize_sharded_default(tmp_zarr, tmp_skeletonize_csv):
     """With sharded=True default, per-ID files are repacked into shard files
     and the info file picks up the sharding spec; one chunk should round-trip


### PR DESCRIPTION
@stuarteberg
## Summary

- **Sharded skeleton output.** `Skeletonize` now writes `neuroglancer_uint64_sharded_v1` by default (`sharded=True`) instead of one file per ID. Workers carry encoded skeleton bytes back through the existing pickle merge; the driver packs them into shards (`shard_bits=1`, `minishard_bits=6` → 2 shard files × 64 minishards). New helper module `util/sharded_skeleton.py`.
- **Seed-voxel fallback.** Lee's 3D thinning can wipe compact/cuboidal objects entirely. When that happens but the EDT still has signal, emit a single seed vertex at the EDT peak with a radius equal to the local half-thickness, so the object keeps a position + radius. New test `test_skeletonize_seed_voxel_fallback` covers a 4×4×4 cube that previously vanished.
- **OOM-driven retry in `dask_util.run_with_oom_retry`.** Ported from mesh-n-bone. On `KilledWorker`, halve `processes`/slot in the dask config and halve `num_workers` to match — doubles per-worker memory while keeping slot/CPU budget constant. Wired into the skeletonize phase via `retry_on_oom` / `memory_retry_max` knobs. No-ops for synchronous, non-jobqueue, or already-at-1-process runs.
- **Encoding/IO split in `CustomSkeleton`.** New `encode_neuroglancer_bytes()` returns the on-disk bytes without writing, so the sharded path can collect bytes in memory. `write_neuroglancer_skeleton` becomes a thin filesystem wrapper. Also coerces edges to `(0, 2)` `uint32` for the single-vertex/seed-voxel case.
- **`assign_to_organelles` cleanup.** `os.remove(coms_path)` → `shutil.rmtree(os.path.dirname(coms_path), ignore_errors=True)` so cleanup works when `coms` is a directory.
- **Tests.** Existing skeletonize tests explicitly pass `sharded=False` so they keep checking per-ID file paths; new test covers the seed-voxel fallback.