### PR TITLE
Bump version to 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cellmap-analyze"
-version = "0.2.2"
+version = "0.2.3"
 description = "Code to perform analysis on segmentations like those produced by CellMap"
 readme = "README.md"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` version 0.2.2 → 0.2.3 so the skeletonize-improvements work merged in #66 (sharded skeleton output, seed-voxel fallback, OOM retries, AssignToOrganelles cleanup) can be tagged and published to PyPI.