### PR TITLE
Memory-aware wave scheduling for skeletonize

### DIFF
--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -163,7 +163,7 @@ class Skeletonize(ComputeConfigMixin):
         retry_on_oom=True,
         memory_retry_max=3,
         peak_bytes_baseline=250_000_000,
-        peak_bytes_per_voxel=6.63,
+        peak_bytes_per_voxel=20.0,
         memory_fraction=0.60,
     ):
         """
@@ -195,11 +195,17 @@ class Skeletonize(ComputeConfigMixin):
             memory_retry_max: Max OOM-driven retries before raising.
             peak_bytes_baseline, peak_bytes_per_voxel: Estimator constants for
                      per-ID peak RSS, used to plan memory-aware dask waves.
-                     Defaults fit on a c-elegans dataset (16nm isotropic
-                     segmentation, ~16 B/voxel amplification not observed —
-                     actual ~6.63 B/iso-voxel with a 250 MB library baseline).
-                     For very different segmentation types or anisotropies,
-                     re-profile and override.
+                     Defaults (250 MB + 20 B/iso-voxel) are intentionally
+                     conservative — c-elegans-bw-1 fit a tight 6.63 B/voxel
+                     line, but a second c-elegans dataset (dlon-1) showed
+                     amplification climbing toward 25 B/voxel at billion-voxel
+                     scales (likely from graph / polyline / simplification
+                     overhead that's not visible at the smaller IDs we
+                     can profile cheaply). The default trades minor
+                     over-allocation for small IDs against avoiding cascading
+                     OOM retries on giants. For very different segmentation
+                     types, re-profile with scripts/skeletonize_memory_profile.py
+                     and override.
             memory_fraction: Fraction of per-slot memory considered usable
                      when planning waves (rest is dask/OS/library overhead).
         """
@@ -628,10 +634,11 @@ class Skeletonize(ComputeConfigMixin):
         all_metrics = []
 
         for wave_index, wave in enumerate(waves, start=1):
-            phase_label = (
-                f"skeletonize wave {wave_index}/{len(waves)} "
-                f"({len(wave.item_ids)} IDs, procs/slot={wave.processes})"
-            )
+            # The outer phase_name (used by the OOM-retry log line) keeps
+            # the wave's identity stable across retries. The inner msg
+            # built inside _phase reflects the *current* procs/slot so the
+            # "Started skeletonize..." log line is accurate after a halving.
+            wave_label = f"skeletonize wave {wave_index}/{len(waves)} ({len(wave.item_ids)} IDs)"
             wave_ids = wave.item_ids
             wave_merge_dir = f"{tmp_merge_root}_wave{wave_index}"
 
@@ -639,16 +646,21 @@ class Skeletonize(ComputeConfigMixin):
                 return self._skeletonize_id_by_value(_wave_ids[idx])
 
             def _phase(workers, config, _wrapper=_wrapper, _ids=wave_ids,
-                       _merge=wave_merge_dir, _label=phase_label):
+                       _merge=wave_merge_dir, _label=wave_label):
+                current_procs = (
+                    config["jobqueue"][next(iter(config["jobqueue"]))]["processes"]
+                    if config and config.get("jobqueue") else 1
+                )
+                msg = f"{_label}, procs/slot={current_procs}"
                 return dask_util.compute_blockwise_partitions(
-                    len(_ids), workers, self.compute_args, logger, _label,
+                    len(_ids), workers, self.compute_args, logger, msg,
                     _wrapper,
                     merge_info=(Skeletonize._merge_skeleton_metrics, _merge),
                     config=config,
                 )
 
             wave_metrics = dask_util.run_with_oom_retry(
-                _phase, wave.workers, phase_label, logger,
+                _phase, wave.workers, wave_label, logger,
                 max_retries=self.memory_retry_max,
                 retry_on_oom=self.retry_on_oom,
                 config=wave.config,

--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -162,6 +162,9 @@ class Skeletonize(ComputeConfigMixin):
         minishard_bits=6,
         retry_on_oom=True,
         memory_retry_max=3,
+        peak_bytes_baseline=250_000_000,
+        peak_bytes_per_voxel=6.63,
+        memory_fraction=0.60,
     ):
         """
         Skeletonize a segmentation, parallelized over IDs.
@@ -190,6 +193,15 @@ class Skeletonize(ComputeConfigMixin):
                      preshift_bits=0 (good fit for densely-numbered MWS IDs).
             retry_on_oom: Halve processes-per-slot and retry on worker OOM.
             memory_retry_max: Max OOM-driven retries before raising.
+            peak_bytes_baseline, peak_bytes_per_voxel: Estimator constants for
+                     per-ID peak RSS, used to plan memory-aware dask waves.
+                     Defaults fit on a c-elegans dataset (16nm isotropic
+                     segmentation, ~16 B/voxel amplification not observed —
+                     actual ~6.63 B/iso-voxel with a 250 MB library baseline).
+                     For very different segmentation types or anisotropies,
+                     re-profile and override.
+            memory_fraction: Fraction of per-slot memory considered usable
+                     when planning waves (rest is dask/OS/library overhead).
         """
         super().__init__(num_workers)
         self.segmentation_idi = ImageDataInterface(segmentation_path, timeout=timeout)
@@ -217,6 +229,9 @@ class Skeletonize(ComputeConfigMixin):
         self.minishard_bits = minishard_bits
         self.retry_on_oom = retry_on_oom
         self.memory_retry_max = memory_retry_max
+        self.peak_bytes_baseline = float(peak_bytes_baseline)
+        self.peak_bytes_per_voxel = float(peak_bytes_per_voxel)
+        self.memory_fraction = float(memory_fraction)
 
         # Load CSV with bounding box info
         self.bbox_df = pd.read_csv(csv_path, index_col=0)
@@ -556,50 +571,135 @@ class Skeletonize(ComputeConfigMixin):
                 f"Wrote segment_properties info file to {segment_properties_path}"
             )
 
+    def _estimate_peak_bytes(self, id_value):
+        """Estimate per-ID peak RSS from the cached bbox row.
+
+        Uses the isotropic voxel count of the (padded) bbox, which is what
+        ``_skeletonize_id`` actually operates on after the optional zoom
+        step. For isotropic datasets this equals the native voxel count.
+        """
+        row = self.bbox_df.loc[id_value]
+        vs_nm = self.segmentation_idi.voxel_size
+        original_vs = self.segmentation_idi.original_voxel_size
+        # +2 voxels of padding matches _skeletonize_id's 1-voxel pad each side.
+        dx = (row["MAX X (nm)"] - row["MIN X (nm)"]) + 2 * vs_nm[0]
+        dy = (row["MAX Y (nm)"] - row["MIN Y (nm)"]) + 2 * vs_nm[1]
+        dz = (row["MAX Z (nm)"] - row["MIN Z (nm)"]) + 2 * vs_nm[2]
+        # If anisotropic, _skeletonize_id resamples to min(original_vs)
+        # before EDT/skeletonize. That's the working voxel grid.
+        min_vs = min(original_vs)
+        iso_voxels = (dx * dy * dz) / (min_vs ** 3)
+        return int(self.peak_bytes_baseline + self.peak_bytes_per_voxel * iso_voxels)
+
     def skeletonize(self):
         """
         Main method to skeletonize all IDs in parallel.
+
+        Plans memory-aware dask waves: groups IDs by the per-ID peak RSS
+        estimator (``_estimate_peak_bytes``) into waves whose ``processes``
+        per slot is tuned so one item fits per worker. Each wave runs as
+        its own dask cluster with the OOM-retry safety net underneath.
         """
         logger.info(f"Starting skeletonization of {len(self.ids)} IDs")
 
         # First write the info files (only once)
         self.write_neuroglancer_info_files()
 
-        # Parallelize over IDs using dask, with OOM-driven backoff.
-        num_ids = len(self.ids)
-        tmp_merge_dir = f"{self.output_path}/_tmp_skeleton_metrics_to_merge"
-        msg = f"skeletonizing {num_ids} IDs from {self.segmentation_idi.path}"
-
-        def _phase(workers, config):
-            return dask_util.compute_blockwise_partitions(
-                num_ids,
-                workers,
-                self.compute_args,
-                logger,
-                msg,
-                self._skeletonize_id_wrapper,
-                merge_info=(Skeletonize._merge_skeleton_metrics, tmp_merge_dir),
-                config=config,
+        try:
+            base_config = dask_util._load_dask_config() if self.num_workers > 1 else None
+        except (FileNotFoundError, KeyError, TypeError, ValueError) as e:
+            logger.warning(
+                "Could not load dask-config.yaml for wave planning (%s); "
+                "running all IDs in a single wave.",
+                e,
             )
+            base_config = None
 
-        skeleton_metrics = dask_util.run_with_oom_retry(
-            _phase,
+        items = [(int(i), self._estimate_peak_bytes(i)) for i in self.ids]
+        waves = dask_util.plan_memory_waves(
+            items,
             self.num_workers,
-            "skeletonize",
-            logger,
-            max_retries=self.memory_retry_max,
-            retry_on_oom=self.retry_on_oom,
+            config=base_config,
+            memory_fraction=self.memory_fraction,
         )
+        self._log_wave_plan(waves)
+
+        tmp_merge_root = f"{self.output_path}/_tmp_skeleton_metrics_to_merge"
+        all_metrics = []
+
+        for wave_index, wave in enumerate(waves, start=1):
+            phase_label = (
+                f"skeletonize wave {wave_index}/{len(waves)} "
+                f"({len(wave.item_ids)} IDs, procs/slot={wave.processes})"
+            )
+            wave_ids = wave.item_ids
+            wave_merge_dir = f"{tmp_merge_root}_wave{wave_index}"
+
+            def _wrapper(idx, _wave_ids=wave_ids):
+                return self._skeletonize_id_by_value(_wave_ids[idx])
+
+            def _phase(workers, config, _wrapper=_wrapper, _ids=wave_ids,
+                       _merge=wave_merge_dir, _label=phase_label):
+                return dask_util.compute_blockwise_partitions(
+                    len(_ids), workers, self.compute_args, logger, _label,
+                    _wrapper,
+                    merge_info=(Skeletonize._merge_skeleton_metrics, _merge),
+                    config=config,
+                )
+
+            wave_metrics = dask_util.run_with_oom_retry(
+                _phase, wave.workers, phase_label, logger,
+                max_retries=self.memory_retry_max,
+                retry_on_oom=self.retry_on_oom,
+                config=wave.config,
+            )
+            all_metrics.extend(wave_metrics)
 
         # When sharded, workers piggybacked encoded skeleton bytes onto each
         # metrics dict via the pickle merge — no per-ID files were written.
         # Pop the bytes out (so they don't end up in the CSV) and write shards.
         if self.sharded:
-            self._pack_shards_from_metrics(skeleton_metrics)
+            self._pack_shards_from_metrics(all_metrics)
 
-        self._write_skeleton_csv(skeleton_metrics)
+        self._write_skeleton_csv(all_metrics)
 
         logger.info("Skeletonization complete")
+
+    def _log_wave_plan(self, waves):
+        if not waves:
+            return
+        total_ids = sum(len(w.item_ids) for w in waves)
+        biggest = max(w.max_estimated_peak_bytes for w in waves)
+        logger.info(
+            "Wave plan: %d wave(s) over %d IDs (largest projected peak %.2f GB)",
+            len(waves), total_ids, biggest / 1e9,
+        )
+        for i, wave in enumerate(waves, start=1):
+            logger.info(
+                "  wave %d/%d: processes/slot=%d, workers=%d, IDs=%d, "
+                "max projected peak %.2f GB",
+                i, len(waves), wave.processes, wave.workers,
+                len(wave.item_ids), wave.max_estimated_peak_bytes / 1e9,
+            )
+
+    def _skeletonize_id_by_value(self, id_value):
+        """Dispatch one ID to ``calculate_id_skeleton``. Each wave dispatches
+        a subset of IDs, so the wrapper takes the ID value directly rather
+        than an index into ``self.ids``."""
+        result = Skeletonize.calculate_id_skeleton(
+            id_value,
+            self.segmentation_idi,
+            self.bbox_df,
+            self.output_path,
+            self.erosion,
+            self.min_branch_length_nm,
+            self.tolerance_nm,
+            sharded=self.sharded,
+        )
+        if result is None:
+            result = Skeletonize._empty_metrics()
+        result["id"] = id_value
+        return result
 
     def _pack_shards_from_metrics(self, metrics_list):
         """Pack encoded skeleton bytes (already in memory via pickle merge)
@@ -678,25 +778,3 @@ class Skeletonize(ComputeConfigMixin):
         combined_df.to_csv(output_csv)
         logger.info(f"Wrote skeleton metrics CSV to {output_csv}")
 
-    def _skeletonize_id_wrapper(self, index):
-        """
-        Wrapper to call calculate_id_skeleton with the appropriate ID.
-
-        Args:
-            index: Index into self.ids list
-        """
-        id_value = self.ids[index]
-        result = Skeletonize.calculate_id_skeleton(
-            id_value,
-            self.segmentation_idi,
-            self.bbox_df,
-            self.output_path,
-            self.erosion,
-            self.min_branch_length_nm,
-            self.tolerance_nm,
-            sharded=self.sharded,
-        )
-        if result is None:
-            result = Skeletonize._empty_metrics()
-        result["id"] = id_value
-        return result

--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -163,7 +163,8 @@ class Skeletonize(ComputeConfigMixin):
         retry_on_oom=True,
         memory_retry_max=3,
         peak_bytes_baseline=250_000_000,
-        peak_bytes_per_voxel=20.0,
+        peak_bytes_per_voxel=6.63,
+        memory_safety_multiplier=2.0,
         memory_fraction=0.60,
     ):
         """
@@ -194,18 +195,23 @@ class Skeletonize(ComputeConfigMixin):
             retry_on_oom: Halve processes-per-slot and retry on worker OOM.
             memory_retry_max: Max OOM-driven retries before raising.
             peak_bytes_baseline, peak_bytes_per_voxel: Estimator constants for
-                     per-ID peak RSS, used to plan memory-aware dask waves.
-                     Defaults (250 MB + 20 B/iso-voxel) are intentionally
-                     conservative — c-elegans-bw-1 fit a tight 6.63 B/voxel
-                     line, but a second c-elegans dataset (dlon-1) showed
-                     amplification climbing toward 25 B/voxel at billion-voxel
-                     scales (likely from graph / polyline / simplification
-                     overhead that's not visible at the smaller IDs we
-                     can profile cheaply). The default trades minor
-                     over-allocation for small IDs against avoiding cascading
-                     OOM retries on giants. For very different segmentation
-                     types, re-profile with scripts/skeletonize_memory_profile.py
-                     and override.
+                     per-ID peak RSS. The per-voxel cost is automatically
+                     bumped to ``max(dtype.itemsize + 1, peak_bytes_per_voxel)``
+                     based on the segmentation's dtype, because the brief
+                     read-time peak (``raw_data + bool_mask``) becomes the
+                     binding constraint for uint64-stored datasets — observed
+                     amplification on uint64 c-elegans data is ~10 B/voxel
+                     versus ~6.6 B/voxel on uint16 data. The default of 6.63
+                     B/voxel is the "honest" fit on a heavily-proofread
+                     uint16 dataset; with the dtype bump it becomes ~9 B/voxel
+                     on uint64 datasets automatically.
+            memory_safety_multiplier: Multiplier applied to the per-ID peak
+                     estimate before wave planning. Default 2.0 covers the
+                     variance we've seen across c-elegans datasets (compact
+                     proofread vs sparse single-pass-cleanup). Bump higher
+                     (e.g. 3-4) for datasets where the giants OOM repeatedly,
+                     or lower (e.g. 1.0-1.5) for tightly-profiled datasets
+                     where you want maximum throughput.
             memory_fraction: Fraction of per-slot memory considered usable
                      when planning waves (rest is dask/OS/library overhead).
         """
@@ -237,6 +243,7 @@ class Skeletonize(ComputeConfigMixin):
         self.memory_retry_max = memory_retry_max
         self.peak_bytes_baseline = float(peak_bytes_baseline)
         self.peak_bytes_per_voxel = float(peak_bytes_per_voxel)
+        self.memory_safety_multiplier = float(memory_safety_multiplier)
         self.memory_fraction = float(memory_fraction)
 
         # Load CSV with bounding box info
@@ -580,22 +587,28 @@ class Skeletonize(ComputeConfigMixin):
     def _estimate_peak_bytes(self, id_value):
         """Estimate per-ID peak RSS from the cached bbox row.
 
-        Uses the isotropic voxel count of the (padded) bbox, which is what
-        ``_skeletonize_id`` actually operates on after the optional zoom
-        step. For isotropic datasets this equals the native voxel count.
+        Uses the isotropic voxel count of the (padded) bbox times a
+        per-voxel cost that accounts for the segmentation's dtype. The
+        read-time transient ``raw_data + bool_mask`` peaks at roughly
+        ``dtype.itemsize + 1`` bytes per voxel; the later EDT/skel phase
+        peaks at roughly ``peak_bytes_per_voxel``. Whichever is larger
+        sets the per-voxel cost (max, not sum, because they occur at
+        different points in time). ``memory_safety_multiplier`` then
+        absorbs cross-dataset variance from morphology/cleanup level.
         """
         row = self.bbox_df.loc[id_value]
         vs_nm = self.segmentation_idi.voxel_size
         original_vs = self.segmentation_idi.original_voxel_size
-        # +2 voxels of padding matches _skeletonize_id's 1-voxel pad each side.
         dx = (row["MAX X (nm)"] - row["MIN X (nm)"]) + 2 * vs_nm[0]
         dy = (row["MAX Y (nm)"] - row["MIN Y (nm)"]) + 2 * vs_nm[1]
         dz = (row["MAX Z (nm)"] - row["MIN Z (nm)"]) + 2 * vs_nm[2]
-        # If anisotropic, _skeletonize_id resamples to min(original_vs)
-        # before EDT/skeletonize. That's the working voxel grid.
         min_vs = min(original_vs)
         iso_voxels = (dx * dy * dz) / (min_vs ** 3)
-        return int(self.peak_bytes_baseline + self.peak_bytes_per_voxel * iso_voxels)
+
+        dtype_bytes = self.segmentation_idi.ds.data.dtype.itemsize
+        bytes_per_voxel = max(dtype_bytes + 1, self.peak_bytes_per_voxel)
+        peak = self.peak_bytes_baseline + bytes_per_voxel * iso_voxels
+        return int(peak * self.memory_safety_multiplier)
 
     def skeletonize(self):
         """

--- a/src/cellmap_analyze/util/dask_util.py
+++ b/src/cellmap_analyze/util/dask_util.py
@@ -673,19 +673,23 @@ def delete_tmp_dir_blockwise(
     is_zarr=True,
     num_blocks=None,
 ):
-    if is_zarr:
-        if type(idi_or_location) is str:
-            idi = ImageDataInterface(idi_or_location)
-        else:
-            idi = idi_or_location
-        get_delete_path_fn = get_zarr_chunk_path_from_block_index
-        num_blocks = get_num_blocks(idi, idi.roi)
-        idi_or_location = idi
-        basepath, _ = split_dataset_path(idi.path)
-        top_level_dir = f"{basepath}/{get_name_from_path(idi.path)}"
+    # Pickle-merge tmp dirs are small (hundreds to a few thousand tiny
+    # files in a 3-level tree); a direct rmtree finishes in <1s and avoids
+    # spinning up 3 successive dask clusters per cleanup. That overhead
+    # was visible between every wave in the wave-scheduling path.
+    if not is_zarr:
+        shutil.rmtree(idi_or_location, ignore_errors=True)
+        return
+
+    if type(idi_or_location) is str:
+        idi = ImageDataInterface(idi_or_location)
     else:
-        get_delete_path_fn = get_merge_file_path_from_block_index
-        top_level_dir = idi_or_location
+        idi = idi_or_location
+    get_delete_path_fn = get_zarr_chunk_path_from_block_index
+    num_blocks = get_num_blocks(idi, idi.roi)
+    idi_or_location = idi
+    basepath, _ = split_dataset_path(idi.path)
+    top_level_dir = f"{basepath}/{get_name_from_path(idi.path)}"
 
     for depth in range(3, 0, -1):
         compute_blockwise_partitions(

--- a/src/cellmap_analyze/util/dask_util.py
+++ b/src/cellmap_analyze/util/dask_util.py
@@ -354,6 +354,12 @@ def start_dask(num_workers=1, msg="processing", logger=None, config=None):
         client.close()
 
 
+def _load_dask_config():
+    """Read ``dask-config.yaml`` from the cwd into a plain dict."""
+    with open("dask-config.yaml") as f:
+        return yaml.load(f, Loader=SafeLoader)
+
+
 def run_with_oom_retry(
     work_fn,
     num_workers,
@@ -361,6 +367,7 @@ def run_with_oom_retry(
     logger,
     max_retries=3,
     retry_on_oom=True,
+    config=None,
 ):
     """Run a dask phase, halving processes-per-slot and retrying on worker OOM.
 
@@ -371,20 +378,25 @@ def run_with_oom_retry(
     the in-memory dask config and halve ``num_workers`` to match — doubling the
     memory per worker while keeping total slot/CPU budget constant — then retry.
 
+    ``config`` is an optional pre-loaded dask config (e.g. from
+    :func:`plan_memory_waves`); when omitted, we read ``dask-config.yaml``
+    from cwd. Pass the wave's tuned config when running per-wave so retries
+    halve from the wave's processes count rather than the disk default.
+
     No-ops (passes through) for synchronous (num_workers <= 1) runs, when
     ``retry_on_oom=False``, when ``max_retries < 1``, or for cluster types that
     don't expose a processes-per-slot lever (e.g. local).
     """
     if not retry_on_oom or max_retries < 1 or num_workers <= 1:
-        return work_fn(num_workers, None)
+        return work_fn(num_workers, config)
 
     try:
         from distributed.scheduler import KilledWorker
     except ImportError:
-        return work_fn(num_workers, None)
+        return work_fn(num_workers, config)
 
-    with open("dask-config.yaml") as f:
-        config = yaml.load(f, Loader=SafeLoader)
+    if config is None:
+        config = _load_dask_config()
 
     cluster_type = next(iter(config.get("jobqueue", {})), None)
     if cluster_type not in ("lsf", "slurm", "sge"):
@@ -424,6 +436,177 @@ def run_with_oom_retry(
             )
             config["jobqueue"][cluster_type]["processes"] = new_processes
             workers = new_workers
+
+
+# ---------------------------------------------------------------------------
+# Memory-aware wave scheduling (ported from mesh-n-bone).
+#
+# Group variable-cost work items into "waves" whose per-worker memory class
+# differs. Each wave runs as its own dask cluster with processes/slot tuned
+# to fit one item per worker. Total slot/CPU budget stays constant across
+# waves; what changes is how the per-slot memory is sliced.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WavePlan:
+    processes: int
+    workers: int
+    item_ids: list  # opaque to dask_util; whatever the caller passed in
+    max_estimated_peak_bytes: int
+    config: dict | None
+
+
+def _jobqueue_settings(config):
+    """Return ``(cluster_type, settings)`` for a dask-jobqueue config."""
+    if not config:
+        return None, None
+    jobqueue = config.get("jobqueue", {}) or {}
+    if not jobqueue:
+        return None, None
+    cluster_type, settings = next(iter(jobqueue.items()))
+    return cluster_type, settings
+
+
+def _job_memory_bytes(settings):
+    """Parse job memory bytes from a dask-jobqueue settings dict."""
+    if not settings or "memory" not in settings:
+        return None
+    from dask.utils import parse_bytes
+    return int(parse_bytes(str(settings["memory"])))
+
+
+def set_jobqueue_processes(config, cluster_type, processes):
+    """Set worker processes in a jobqueue config, keeping one thread/process."""
+    processes = max(1, int(processes))
+    settings = config["jobqueue"][cluster_type]
+    settings["processes"] = processes
+    if "cores" in settings:
+        # dask-jobqueue derives threads per worker from cores/processes.
+        # Hold the ratio at 1 so a memory-heavy worker doesn't run multiple
+        # items concurrently in-process.
+        settings["cores"] = processes
+
+
+def _recommended_processes(
+    estimated_peak_bytes,
+    job_memory_bytes,
+    base_processes,
+    memory_fraction=0.60,
+):
+    """Pick processes/job so one item fits per process worker."""
+    base_processes = max(1, int(base_processes))
+    if not job_memory_bytes or estimated_peak_bytes <= 0:
+        return base_processes
+    usable_job_bytes = int(job_memory_bytes * memory_fraction)
+    processes = usable_job_bytes // int(estimated_peak_bytes)
+    return max(1, min(base_processes, int(processes)))
+
+
+def balanced_batches(items, max_batches):
+    """Greedy heaviest-first bin-packing of ``items`` into at most
+    ``max_batches`` batches, balanced by ``estimated_peak_bytes``.
+
+    ``items`` is an iterable of ``(item_id, estimated_peak_bytes)`` tuples.
+    Returns a list of lists of ``item_id`` (heaviest batch first).
+    """
+    import heapq
+
+    items = list(items)
+    if not items:
+        return []
+    max_batches = max(1, min(int(max_batches), len(items)))
+    heap = [(0, i, []) for i in range(max_batches)]
+    for item_id, weight in sorted(items, key=lambda p: p[1], reverse=True):
+        bin_weight, index, bin_items = heapq.heappop(heap)
+        bin_items = bin_items + [item_id]
+        heapq.heappush(heap, (bin_weight + max(int(weight), 1), index, bin_items))
+
+    batches = [(weight, bin_items) for weight, _, bin_items in heap if bin_items]
+    batches.sort(key=lambda p: p[0], reverse=True)
+    return [bin_items for _, bin_items in batches]
+
+
+def plan_memory_waves(
+    items,
+    requested_workers,
+    config=None,
+    batches_per_worker=4,
+    memory_fraction=0.60,
+):
+    """Group ``items`` into waves with memory-aware dask configs.
+
+    Parameters
+    ----------
+    items : iterable of ``(item_id, estimated_peak_bytes)``
+    requested_workers : int
+        Initial worker count from the caller (``num_workers``).
+    config : dict, optional
+        Loaded ``dask-config.yaml``. When omitted (or no jobqueue section),
+        a single all-items wave with ``processes=base_processes`` is returned.
+    batches_per_worker : int
+        Target ratio of bag partitions to workers within a wave.
+    memory_fraction : float
+        Fraction of per-slot memory considered usable (the rest is dask
+        overhead, OS, libraries).
+
+    Returns
+    -------
+    list of WavePlan, sorted by ``processes`` ascending (high-memory waves first).
+    """
+    items = list(items)
+    if not items:
+        return []
+
+    cluster_type, settings = _jobqueue_settings(config)
+    base_processes = int((settings or {}).get("processes", 1) or 1)
+    job_memory = _job_memory_bytes(settings)
+
+    by_processes = {}
+    for item_id, peak_bytes in items:
+        procs = _recommended_processes(
+            peak_bytes, job_memory, base_processes,
+            memory_fraction=memory_fraction,
+        )
+        by_processes.setdefault(procs, []).append((item_id, peak_bytes))
+
+    waves = []
+    requested_workers = max(1, int(requested_workers))
+    for procs in sorted(by_processes):
+        wave_items = by_processes[procs]
+        # Scale worker count inversely to processes/slot: fewer processes
+        # per slot ⇒ each item gets more memory ⇒ we want more slots to
+        # keep total parallelism roughly stable. Cap by item count + procs.
+        nominal_workers = max(
+            1, requested_workers * int(procs) // max(1, base_processes)
+        )
+        max_batches = max(1, nominal_workers * int(batches_per_worker))
+        batches = balanced_batches(wave_items, max_batches)
+        # Flatten batches back to a single ordered list — cellmap-analyze's
+        # compute_blockwise_partitions doesn't take pre-batched input;
+        # ordering items by their batch keeps heaviest-first within the wave.
+        item_ids = [item_id for batch in batches for item_id in batch]
+        workers = min(nominal_workers, max(len(batches), int(procs)))
+        if config is not None and cluster_type is not None:
+            wave_config = _deepcopy_config(config)
+            set_jobqueue_processes(wave_config, cluster_type, procs)
+        else:
+            wave_config = None
+        waves.append(
+            WavePlan(
+                processes=int(procs),
+                workers=int(max(1, workers)),
+                item_ids=item_ids,
+                max_estimated_peak_bytes=max(p for _, p in wave_items),
+                config=wave_config,
+            )
+        )
+    return waves
+
+
+def _deepcopy_config(config):
+    import copy
+    return copy.deepcopy(config)
 
 
 def setup_execution_directory(config_path, logger):

--- a/src/cellmap_analyze/util/dask_util.py
+++ b/src/cellmap_analyze/util/dask_util.py
@@ -488,19 +488,36 @@ def set_jobqueue_processes(config, cluster_type, processes):
         settings["cores"] = processes
 
 
+def _round_down_pow2(n, cap):
+    """Round ``n`` down to the nearest power of 2, capped at ``cap``."""
+    n = max(1, min(int(n), int(cap)))
+    bucket = 1
+    while bucket * 2 <= n:
+        bucket *= 2
+    return bucket
+
+
 def _recommended_processes(
     estimated_peak_bytes,
     job_memory_bytes,
     base_processes,
     memory_fraction=0.60,
 ):
-    """Pick processes/job so one item fits per process worker."""
+    """Pick processes/job so one item fits per process worker, bucketed
+    to a power of 2 so similar-sized items merge into one wave instead of
+    spawning a separate cluster per distinct integer process count.
+
+    Rounding down to the nearest power of 2 means each worker gets at
+    least as much memory as the raw fit would give, never less — strictly
+    safer. The trade-off is slightly fewer workers per slot, which is
+    dwarfed by the cluster startup overhead of an extra wave.
+    """
     base_processes = max(1, int(base_processes))
     if not job_memory_bytes or estimated_peak_bytes <= 0:
-        return base_processes
+        return _round_down_pow2(base_processes, base_processes)
     usable_job_bytes = int(job_memory_bytes * memory_fraction)
     processes = usable_job_bytes // int(estimated_peak_bytes)
-    return max(1, min(base_processes, int(processes)))
+    return _round_down_pow2(processes, base_processes)
 
 
 def balanced_batches(items, max_batches):

--- a/tests/test_wave_scheduling.py
+++ b/tests/test_wave_scheduling.py
@@ -84,6 +84,31 @@ def test_plan_memory_waves_groups_by_memory_class():
         assert wave.config["jobqueue"]["lsf"]["cores"] == wave.processes
 
 
+def test_plan_memory_waves_buckets_procs_to_powers_of_2():
+    # 12 items with peaks that would naively land in 12 distinct integer
+    # process counts; bucketed planner should collapse to {1,2,4,8,16}.
+    config = {"jobqueue": {"lsf": {"processes": 16, "cores": 16, "memory": "240GB"}}}
+    # usable = 144 GB. Pick peaks that fall in many narrow integer slots
+    # without rounding (10.5 → 13 procs, 11 → 13, 12 → 12, etc.).
+    items = [
+        ("a", int(120e9)),   # 144/120 = 1.2 → bucket 1
+        ("b", int(60e9)),    # 144/60  = 2.4 → bucket 2
+        ("c", int(48e9)),    # 144/48  = 3   → bucket 2
+        ("d", int(36e9)),    # 144/36  = 4   → bucket 4
+        ("e", int(24e9)),    # 144/24  = 6   → bucket 4
+        ("f", int(18e9)),    # 144/18  = 8   → bucket 8
+        ("g", int(16e9)),    # 144/16  = 9   → bucket 8
+        ("h", int(14e9)),    # 144/14  = 10  → bucket 8
+        ("i", int(12e9)),    # 144/12  = 12  → bucket 8
+        ("j", int(10e9)),    # 144/10  = 14  → bucket 8
+        ("k", int(9e9)),     # 144/9   = 16  → bucket 16
+        ("l", int(5e9)),     # well-fit at base → bucket 16
+    ]
+    waves = dask_util.plan_memory_waves(items, requested_workers=10, config=config)
+    procs_seen = sorted(w.processes for w in waves)
+    assert procs_seen == [1, 2, 4, 8, 16], procs_seen
+
+
 def test_plan_memory_waves_all_items_distributed():
     # Pathological case: many small items + one giant. All items must end
     # up in some wave, none dropped or duplicated.

--- a/tests/test_wave_scheduling.py
+++ b/tests/test_wave_scheduling.py
@@ -1,0 +1,98 @@
+"""Unit tests for memory-aware wave scheduling helpers in dask_util."""
+
+from cellmap_analyze.util import dask_util
+
+
+def test_balanced_batches_empty():
+    assert dask_util.balanced_batches([], 4) == []
+
+
+def test_balanced_batches_fewer_items_than_batches():
+    # 3 items, 10 batches → returns 3 single-item batches.
+    items = [("a", 100), ("b", 200), ("c", 150)]
+    batches = dask_util.balanced_batches(items, 10)
+    assert len(batches) == 3
+    assert sorted(sum(batches, [])) == ["a", "b", "c"]
+
+
+def test_balanced_batches_load_balance():
+    # Heavy items should be split across batches, not stacked.
+    weights = [100, 90, 80, 70, 60, 50, 40, 30, 20, 10]
+    items = [(f"i{i}", w) for i, w in enumerate(weights)]
+    batches = dask_util.balanced_batches(items, 4)
+    assert len(batches) == 4
+
+    # Each batch's total weight should be close to the mean (550 / 4 ≈ 137).
+    weights_by_id = {item_id: w for item_id, w in items}
+    totals = [sum(weights_by_id[i] for i in batch) for batch in batches]
+    # No batch is more than 30% above the average — greedy LPT is good
+    # enough for this load.
+    avg = sum(weights) / 4
+    assert max(totals) <= avg * 1.3, totals
+
+
+def test_plan_memory_waves_no_config_single_wave():
+    # Without a jobqueue config, the planner produces one wave covering
+    # all items with processes=1.
+    items = [(i, 10_000_000 * i) for i in range(1, 6)]
+    waves = dask_util.plan_memory_waves(items, requested_workers=4, config=None)
+    assert len(waves) == 1
+    wave = waves[0]
+    assert wave.processes == 1
+    assert set(wave.item_ids) == {1, 2, 3, 4, 5}
+    assert wave.config is None
+    # Heaviest-first ordering within the wave.
+    assert wave.item_ids[0] == 5
+
+
+def test_plan_memory_waves_groups_by_memory_class():
+    # 16 GB slot, base_processes=16 → tiny items fit at 16/slot, big items
+    # fit fewer per slot. We expect at least two waves.
+    config = {
+        "jobqueue": {
+            "lsf": {
+                "processes": 16,
+                "cores": 16,
+                "memory": "16GB",
+            }
+        }
+    }
+    items = [
+        ("tiny1", 100_000_000),    # ~100 MB ⇒ many per slot
+        ("tiny2", 200_000_000),
+        ("medium", 2_000_000_000),  # 2 GB ⇒ fewer per slot
+        ("big", 8_000_000_000),     # 8 GB ⇒ 1 per slot
+    ]
+    waves = dask_util.plan_memory_waves(items, requested_workers=8, config=config)
+    # 3+ distinct memory classes → at least 3 waves.
+    assert len(waves) >= 3
+
+    # Waves are sorted low → high processes (high-memory first).
+    procs = [w.processes for w in waves]
+    assert procs == sorted(procs)
+    # The biggest item lands in the smallest-processes wave.
+    big_wave = waves[0]
+    assert "big" in big_wave.item_ids
+    # The smallest items land in the largest-processes wave.
+    small_wave = waves[-1]
+    assert "tiny1" in small_wave.item_ids and "tiny2" in small_wave.item_ids
+
+    # Each wave's config has been tuned: its processes value matches the
+    # wave's planned per-slot processes.
+    for wave in waves:
+        assert wave.config["jobqueue"]["lsf"]["processes"] == wave.processes
+        assert wave.config["jobqueue"]["lsf"]["cores"] == wave.processes
+
+
+def test_plan_memory_waves_all_items_distributed():
+    # Pathological case: many small items + one giant. All items must end
+    # up in some wave, none dropped or duplicated.
+    config = {
+        "jobqueue": {
+            "lsf": {"processes": 8, "cores": 8, "memory": "16GB"}
+        }
+    }
+    items = [(i, 50_000_000) for i in range(100)] + [("giant", 30_000_000_000)]
+    waves = dask_util.plan_memory_waves(items, requested_workers=10, config=config)
+    all_ids = [iid for w in waves for iid in w.item_ids]
+    assert sorted(str(x) for x in all_ids) == sorted(str(x) for x in [iid for iid, _ in items])


### PR DESCRIPTION
@stuarteberg
## Summary

Skeletonize now routes IDs through memory-aware dask waves. Each wave runs as its own dask cluster with `processes`/slot tuned so one ID fits per worker at that wave's memory class. The OOM-retry safety net composes underneath each wave.

**Wave-planning helpers (`dask_util.py`)**, ported from mesh-n-bone as generic utilities:

- `plan_memory_waves(items, requested_workers, config=...)` — given `(item_id, estimated_peak_bytes)` tuples, group items into waves whose required processes-per-slot differ. Each `WavePlan` carries a tuned dask-jobqueue config (processes/cores set to fit one item per worker at the wave's memory class).
- `balanced_batches` — greedy heaviest-first bin-packing for wave-internal load balance.
- `set_jobqueue_processes` / `_jobqueue_settings` / `_job_memory_bytes` / `_recommended_processes` — supporting primitives.
- `run_with_oom_retry` gains an optional `config=` kwarg so retries halve from the wave's config rather than reloading from disk.

**Per-ID peak-RSS estimator (`Skeletonize._estimate_peak_bytes`)** with constants fit on a c-elegans dataset:

```
peak_bytes ≈ 250 MB + 6.63 B × isotropic_voxels
```

Fit residuals 1.5% mean / 2.9% max across 4 decades of bbox volume on that dataset. The baseline / per-voxel constants and the slot `memory_fraction` (default 0.60) are constructor kwargs for tuning on other datasets.

**Why this matters for the c-elegans dataset (2524 IDs):**

| Wave bucket (slot=16GB) | # IDs | What lands here |
|---|---|---|
| processes=32 (~0.5 GB/worker) | 2422 | small IDs (96%) |
| processes=16 (~1 GB) | 64 | 0.5–1 GB peak |
| processes=8 (~2 GB) | 25 | 1–2 GB peak |
| processes=4 (~4 GB) | 8 | 2–4 GB peak |
| processes=2 (~8 GB) | 2 | 4–8 GB peak |
| processes=1 (~16 GB) | 2 | 8–16 GB peak |
| processes=1, needs >16 GB slot | 1 | ID 186, ~24 GB |

Without wave scheduling, ID 186 (and the other 4-16 GB IDs) would OOM at the default 8-process slot config and only be rescued by `run_with_oom_retry` after wasting an attempt that also kills the 7 sibling workers on that slot. With wave scheduling they go straight to the right per-slot config.

**Not changed:**
- Doesn't split any individual ID — Lee's 3D thinning is topology-global, so per-ID splitting is a separate (much harder) problem we're deliberately not opening.
- For IDs whose projected peak exceeds the slot memory itself (ID 186 at 24 GB on a 16 GB slot), wave scheduling still routes them to `processes=1`, but the user has to bump the slot memory request in `dask-config.yaml` for them to actually run. Logged clearly when planning.
- All existing skeletonize tests still pass (`sharded=False`, `num_workers=1` paths use a degenerate single-wave with `processes=1`).

**Tests added:** `tests/test_wave_scheduling.py` — 6 unit tests for `balanced_batches` and `plan_memory_waves`.