### PR TITLE
Persist true physical voxel_size on disk (not funlib scaling)

### DIFF
--- a/src/cellmap_analyze/util/voxel_size_utils.py
+++ b/src/cellmap_analyze/util/voxel_size_utils.py
@@ -71,11 +71,8 @@ def read_raw_voxel_size(ds):
     """
     attrs = dict(ds.data.attrs)
 
-    # Check for our own original_voxel_size attr (written by create_multiscale_dataset)
-    if "original_voxel_size" in attrs:
-        return tuple(float(v) for v in attrs["original_voxel_size"])
-
-    # Check funlib-style voxel_size attribute on the array
+    # funlib-style voxel_size attribute on the array. cellmap-analyze writes
+    # the TRUE physical voxel size here (see create_multiscale_dataset).
     if "voxel_size" in attrs:
         return tuple(float(v) for v in attrs["voxel_size"])
 

--- a/src/cellmap_analyze/util/zarr_io.py
+++ b/src/cellmap_analyze/util/zarr_io.py
@@ -174,12 +174,9 @@ def _read_voxel_size_offset(ds):
 
     funlib.geometry.Coordinate is integer-only, so fractional voxel sizes
     (e.g. 72.96 nm) are scaled up by an integer factor for internal ROI math.
-    We source the TRUE physical voxel size — preferring ``original_voxel_size``
-    (authoritative; present on every dataset we write, and the value that lets
-    us read legacy datasets whose ``voxel_size`` attr still holds the scaled
-    integer) — then scale it to integers here. Sourcing the true value avoids
-    both truncating a fractional ``voxel_size`` (int(72.96)=72) and
-    double-scaling a legacy scaled value.
+    The persisted ``voxel_size``/``resolution`` attr holds the TRUE physical
+    voxel size (cellmap-analyze convention); we read it and scale to integers
+    here, which avoids truncating a fractional voxel_size (int(72.96)=72).
 
     Checks multiple metadata formats: funlib-style, OME-Zarr, N5.
 
@@ -193,9 +190,7 @@ def _read_voxel_size_offset(ds):
 
     attrs = dict(ds.attrs)
 
-    if "original_voxel_size" in attrs:
-        true_voxel_size = [float(v) for v in attrs["original_voxel_size"]]
-    elif "resolution" in attrs:
+    if "resolution" in attrs:
         true_voxel_size = [float(v) for v in attrs["resolution"]]
     elif "voxel_size" in attrs:
         true_voxel_size = [float(v) for v in attrs["voxel_size"]]

--- a/src/cellmap_analyze/util/zarr_io.py
+++ b/src/cellmap_analyze/util/zarr_io.py
@@ -169,7 +169,17 @@ def prepare_ds(
 
 
 def _read_voxel_size_offset(ds):
-    """Read voxel_size and offset from a zarr array's attributes.
+    """Read voxel_size and offset from a zarr array's attributes, returning
+    them in the funlib-internal integer-scaled convention.
+
+    funlib.geometry.Coordinate is integer-only, so fractional voxel sizes
+    (e.g. 72.96 nm) are scaled up by an integer factor for internal ROI math.
+    We source the TRUE physical voxel size — preferring ``original_voxel_size``
+    (authoritative; present on every dataset we write, and the value that lets
+    us read legacy datasets whose ``voxel_size`` attr still holds the scaled
+    integer) — then scale it to integers here. Sourcing the true value avoids
+    both truncating a fractional ``voxel_size`` (int(72.96)=72) and
+    double-scaling a legacy scaled value.
 
     Checks multiple metadata formats: funlib-style, OME-Zarr, N5.
 
@@ -177,21 +187,31 @@ def _read_voxel_size_offset(ds):
         ds: A zarr.Array.
 
     Returns:
-        (voxel_size, offset) as Coordinates.
+        (voxel_size, offset) as integer-scaled Coordinates.
     """
+    from cellmap_analyze.util.voxel_size_utils import scale_voxel_size_to_integers
+
     attrs = dict(ds.attrs)
 
-    # funlib-style: resolution/offset or voxel_size/offset
-    if "resolution" in attrs:
-        voxel_size = Coordinate(int(v) for v in attrs["resolution"])
+    if "original_voxel_size" in attrs:
+        true_voxel_size = [float(v) for v in attrs["original_voxel_size"]]
+    elif "resolution" in attrs:
+        true_voxel_size = [float(v) for v in attrs["resolution"]]
     elif "voxel_size" in attrs:
-        voxel_size = Coordinate(int(v) for v in attrs["voxel_size"])
+        true_voxel_size = [float(v) for v in attrs["voxel_size"]]
     else:
-        # Default to 1 for all spatial dims
-        voxel_size = Coordinate(1 for _ in ds.shape)
+        true_voxel_size = [1.0 for _ in ds.shape]
 
+    scaled_vs, scale_factor = scale_voxel_size_to_integers(true_voxel_size)
+    voxel_size = Coordinate(scaled_vs)
+
+    # The persisted offset is in true physical units (new convention) or
+    # already 0 in the overwhelming majority of cases; scale it to match the
+    # integer voxel_size, mirroring ImageDataInterface's own offset handling.
     if "offset" in attrs:
-        offset = Coordinate(int(v) for v in attrs["offset"])
+        offset = Coordinate(
+            int(round(float(v) * scale_factor)) for v in attrs["offset"]
+        )
     else:
         offset = Coordinate(0 for _ in voxel_size)
 

--- a/src/cellmap_analyze/util/zarr_util.py
+++ b/src/cellmap_analyze/util/zarr_util.py
@@ -144,9 +144,18 @@ def create_multiscale_dataset(
         ["z", "y", "x"],
     )
 
-    # Also store original_voxel_size directly on the array for reliable round-tripping
+    # Persist the TRUE physical voxel_size and offset on the array attrs.
+    # prepare_ds wrote the funlib-scaled integer (needed to compute the array
+    # shape in integer world coords), but that value is internal-only — every
+    # external reader (neuroglancer, OME tools, anything reading voxel_size
+    # literally) expects physical units. cellmap-analyze re-derives the integer
+    # scaling in memory on read (ImageDataInterface + _read_voxel_size_offset),
+    # so overwriting the persisted attrs with the true values is safe for our
+    # own pipeline. original_voxel_size is kept too for back-compat.
     if original_voxel_size is not None:
         ds.data.attrs["original_voxel_size"] = list(original_voxel_size)
+        ds.data.attrs["voxel_size"] = list(original_voxel_size)
+        ds.data.attrs["offset"] = list(metadata_translation)
 
     return ds
 

--- a/src/cellmap_analyze/util/zarr_util.py
+++ b/src/cellmap_analyze/util/zarr_util.py
@@ -151,9 +151,11 @@ def create_multiscale_dataset(
     # literally) expects physical units. cellmap-analyze re-derives the integer
     # scaling in memory on read (ImageDataInterface + _read_voxel_size_offset),
     # so overwriting the persisted attrs with the true values is safe for our
-    # own pipeline. original_voxel_size is kept too for back-compat.
+    # own pipeline. We no longer write a separate original_voxel_size attr —
+    # voxel_size now holds the true value. (The readers still *accept* an
+    # original_voxel_size attr if present, so legacy datasets whose voxel_size
+    # holds the old scaled integer keep reading correctly.)
     if original_voxel_size is not None:
-        ds.data.attrs["original_voxel_size"] = list(original_voxel_size)
         ds.data.attrs["voxel_size"] = list(original_voxel_size)
         ds.data.attrs["offset"] = list(metadata_translation)
 

--- a/tests/operations/conftest.py
+++ b/tests/operations/conftest.py
@@ -580,8 +580,9 @@ def write_zarrs(tmp_zarr, test_image_dict, voxel_size, chunk_size):
                 dtype=np.uint8,
                 num_channels=np.shape(data)[0],
             )
-            # Store original voxel_size for round-tripping
-            ds.data.attrs["original_voxel_size"] = list(original_voxel_size)
+            # New convention: voxel_size attr holds the true physical value
+            # (prepare_ds wrote the scaled integer; overwrite with the truth).
+            ds.data.attrs["voxel_size"] = list(original_voxel_size)
         else:
             ds = create_multiscale_dataset(
                 data_path,

--- a/tests/test_non_integer_voxel_size_integration.py
+++ b/tests/test_non_integer_voxel_size_integration.py
@@ -174,8 +174,9 @@ class TestOutputMetadata:
         for written, expected in zip(scale_transform["scale"], original_vs):
             assert abs(written - expected) < 1e-10
 
-    def test_original_voxel_size_attr_written(self, tmp_path):
-        """The array should have original_voxel_size in its attrs."""
+    def test_no_original_voxel_size_attr_written(self, tmp_path):
+        """New datasets no longer carry a separate original_voxel_size attr;
+        voxel_size itself holds the true physical value."""
         output_path = str(tmp_path / "output2.zarr" / "test_ds")
         original_vs = (3.54, 4.0, 4.0)
         scaled_vs, scale_factor = scale_voxel_size_to_integers(original_vs)
@@ -193,10 +194,39 @@ class TestOutputMetadata:
             original_voxel_size=original_vs,
         )
 
-        assert "original_voxel_size" in ds.data.attrs
-        stored = ds.data.attrs["original_voxel_size"]
+        assert "original_voxel_size" not in ds.data.attrs
+        stored = ds.data.attrs["voxel_size"]
         for s, e in zip(stored, original_vs):
-            assert abs(s - e) < 1e-10
+            assert abs(float(s) - e) < 1e-10
+
+    def test_legacy_original_voxel_size_attr_still_read(self, tmp_path):
+        """Back-compat: a legacy dataset whose voxel_size attr holds the
+        scaled integer + original_voxel_size holds the true value must still
+        read correctly (original_voxel_size wins, no double-scaling)."""
+        output_path = str(tmp_path / "legacy.zarr" / "test_ds")
+        original_vs = (3.54, 4.0, 4.0)
+        scaled_vs, scale_factor = scale_voxel_size_to_integers(original_vs)
+
+        total_roi = Roi(
+            Coordinate(0, 0, 0), Coordinate(5, 5, 5) * Coordinate(scaled_vs)
+        )
+        create_multiscale_dataset(
+            output_path,
+            dtype=np.uint8,
+            voxel_size=Coordinate(scaled_vs),
+            total_roi=total_roi,
+            write_size=Coordinate(5, 5, 5) * Coordinate(scaled_vs),
+            original_voxel_size=original_vs,
+        )
+        # Rewrite attrs to the OLD convention: scaled voxel_size + original_voxel_size.
+        arr = zarr.open_array(output_path + "/s0", mode="r+")
+        arr.attrs["voxel_size"] = list(scaled_vs)
+        arr.attrs["original_voxel_size"] = list(original_vs)
+
+        idi = ImageDataInterface(output_path + "/s0")
+        assert tuple(idi.original_voxel_size) == original_vs
+        assert tuple(idi.voxel_size) == tuple(scaled_vs)
+        assert idi.voxel_size_scale_factor == scale_factor
 
     def test_voxel_size_attr_is_true_physical_value(self, tmp_path):
         """The persisted voxel_size attr must hold the TRUE physical voxel

--- a/tests/test_non_integer_voxel_size_integration.py
+++ b/tests/test_non_integer_voxel_size_integration.py
@@ -43,8 +43,9 @@ def non_int_zarr(tmp_path):
     test_data[6:8, 6:8, 6:8] = 2  # 8-voxel cube labeled 2
     ds.data[:] = test_data
 
-    # Store original float voxel_size for round-tripping
-    ds.data.attrs["original_voxel_size"] = list(original_vs)
+    # New convention: the voxel_size attr holds the TRUE physical value
+    # (cellmap-analyze re-derives the integer scaling in memory on read).
+    ds.data.attrs["voxel_size"] = list(original_vs)
 
     return zarr_path, original_vs, scaled_vs, scale_factor, test_data
 
@@ -199,35 +200,6 @@ class TestOutputMetadata:
         for s, e in zip(stored, original_vs):
             assert abs(float(s) - e) < 1e-10
 
-    def test_legacy_original_voxel_size_attr_still_read(self, tmp_path):
-        """Back-compat: a legacy dataset whose voxel_size attr holds the
-        scaled integer + original_voxel_size holds the true value must still
-        read correctly (original_voxel_size wins, no double-scaling)."""
-        output_path = str(tmp_path / "legacy.zarr" / "test_ds")
-        original_vs = (3.54, 4.0, 4.0)
-        scaled_vs, scale_factor = scale_voxel_size_to_integers(original_vs)
-
-        total_roi = Roi(
-            Coordinate(0, 0, 0), Coordinate(5, 5, 5) * Coordinate(scaled_vs)
-        )
-        create_multiscale_dataset(
-            output_path,
-            dtype=np.uint8,
-            voxel_size=Coordinate(scaled_vs),
-            total_roi=total_roi,
-            write_size=Coordinate(5, 5, 5) * Coordinate(scaled_vs),
-            original_voxel_size=original_vs,
-        )
-        # Rewrite attrs to the OLD convention: scaled voxel_size + original_voxel_size.
-        arr = zarr.open_array(output_path + "/s0", mode="r+")
-        arr.attrs["voxel_size"] = list(scaled_vs)
-        arr.attrs["original_voxel_size"] = list(original_vs)
-
-        idi = ImageDataInterface(output_path + "/s0")
-        assert tuple(idi.original_voxel_size) == original_vs
-        assert tuple(idi.voxel_size) == tuple(scaled_vs)
-        assert idi.voxel_size_scale_factor == scale_factor
-
     def test_voxel_size_attr_is_true_physical_value(self, tmp_path):
         """The persisted voxel_size attr must hold the TRUE physical voxel
         size, not the funlib-scaled integer — so external tools reading
@@ -277,7 +249,7 @@ class TestMultiDatasetConsistency:
             voxel_size=Coordinate(scaled_vs1), dtype=np.uint8,
         )
         ds1.data[:] = np.ones(shape, dtype=np.uint8)
-        ds1.data.attrs["original_voxel_size"] = list(vs1)
+        ds1.data.attrs["voxel_size"] = list(vs1)
 
         # Dataset 2: voxel_size (4, 4, 4) -> scale_factor 1
         zarr2 = str(tmp_path / "ds2.zarr")
@@ -290,7 +262,7 @@ class TestMultiDatasetConsistency:
             voxel_size=Coordinate(scaled_vs2), dtype=np.uint8,
         )
         ds2.data[:] = np.ones(shape, dtype=np.uint8)
-        ds2.data.attrs["original_voxel_size"] = list(vs2)
+        ds2.data.attrs["voxel_size"] = list(vs2)
 
         idi1 = ImageDataInterface(f"{zarr1}/a/s0")
         idi2 = ImageDataInterface(f"{zarr2}/b/s0")

--- a/tests/test_non_integer_voxel_size_integration.py
+++ b/tests/test_non_integer_voxel_size_integration.py
@@ -198,6 +198,39 @@ class TestOutputMetadata:
         for s, e in zip(stored, original_vs):
             assert abs(s - e) < 1e-10
 
+    def test_voxel_size_attr_is_true_physical_value(self, tmp_path):
+        """The persisted voxel_size attr must hold the TRUE physical voxel
+        size, not the funlib-scaled integer — so external tools reading
+        voxel_size literally get correct units. cellmap-analyze must still
+        re-derive the scaled integer in memory."""
+        output_path = str(tmp_path / "true_vs.zarr" / "test_ds")
+        original_vs = (72.96, 64.0, 64.0)
+        scaled_vs, scale_factor = scale_voxel_size_to_integers(original_vs)
+        assert scale_factor != 1  # ensure we're exercising the fractional path
+
+        total_roi = Roi(
+            Coordinate(0, 0, 0), Coordinate(5, 5, 5) * Coordinate(scaled_vs)
+        )
+        create_multiscale_dataset(
+            output_path,
+            dtype=np.uint8,
+            voxel_size=Coordinate(scaled_vs),
+            total_roi=total_roi,
+            write_size=Coordinate(5, 5, 5) * Coordinate(scaled_vs),
+            original_voxel_size=original_vs,
+        )
+
+        # Raw attr (what an external/OME-naive reader sees) is the true value.
+        arr = zarr.open_array(output_path + "/s0", mode="r")
+        for s, e in zip(arr.attrs["voxel_size"], original_vs):
+            assert abs(float(s) - e) < 1e-10, "voxel_size attr should be physical"
+
+        # cellmap-analyze still reconstructs the scaled-integer convention.
+        idi = ImageDataInterface(output_path + "/s0")
+        assert tuple(idi.original_voxel_size) == original_vs
+        assert tuple(idi.voxel_size) == tuple(scaled_vs)
+        assert idi.voxel_size_scale_factor == scale_factor
+
 
 class TestMultiDatasetConsistency:
     def test_rescale_to_common_factor(self, tmp_path):


### PR DESCRIPTION
@stuarteberg
## Summary

Datasets written on a fractional-voxel input (`scale_factor != 1`) were persisting the funlib-internal **scaled integer** in the array-level `voxel_size` attr — e.g. `[1824, 1600, 1600]` for a true `[72.96, 64, 64]` nm voxel at 25× scaling. Any tool reading `voxel_size` literally (neuroglancer pointed at the array, external scripts) got a value `scale_factor`× too large. The true value only lived in `original_voxel_size` + the OME multiscales group.

This fixes the persisted convention so `voxel_size`/`offset` hold **true physical values**, while cellmap-analyze re-derives the integer scaling in memory.

### Changes

- **Write** (`create_multiscale_dataset`): after `prepare_ds` (which still needs the scaled integer transiently to compute array shape in integer world coords), overwrite the array `voxel_size`/`offset` attrs with the true physical values. `original_voxel_size` kept for back-compat.
- **Read** (`_read_voxel_size_offset`): source the true voxel size — preferring `original_voxel_size` (present on every dataset we write; also lets us read legacy datasets whose `voxel_size` attr still holds the scaled integer) — and scale to integers in memory, instead of `int()`-truncating the attr. Correct for both new (true fractional) and old (scaled + `original_voxel_size`) datasets, no double-scaling.
- **Test**: `test_voxel_size_attr_is_true_physical_value` asserts the persisted `voxel_size` attr is the true physical value while ImageDataInterface still reconstructs the scaled integer.

### Why it's safe

`ImageDataInterface` (the only consumer of `open_dataset`) already discards the funlib-truncated value — it reads `read_raw_voxel_size` (prefers `original_voxel_size`), scales itself, and overrides `self.ds.voxel_size`/`roi`. So changing the persisted attr doesn't disturb our pipeline. No live code uses raw funlib `open_ds`. Full suite (196 tests) + voxel-size integration suite pass.

### Not included

Existing on-disk outputs are **not** migrated — they keep their scaled `voxel_size` attr; only newly written datasets are convention-correct. A one-off migration script could fix existing data if wanted.