### PR TITLE
Treat OME translation as voxel center; fix multiscale level read

### DIFF
--- a/src/cellmap_analyze/util/image_data_interface.py
+++ b/src/cellmap_analyze/util/image_data_interface.py
@@ -495,6 +495,16 @@ class ImageDataInterface:
             raw_voxel_size = raw_voxel_size[::-1]
             raw_offset = raw_offset[::-1]
 
+        # The persisted offset / OME-NGFF translation is the physical position
+        # of the voxel CENTER of voxel [0,0,0]. funlib ROI math treats the
+        # offset as the voxel CORNER (begin). Convert center -> corner by
+        # subtracting half a voxel so every internal voxel<->physical
+        # conversion (measure's +0.5, assign's floor, block IO) is consistent
+        # and datasets at different scales line up. The write path
+        # (create_multiscale_dataset) converts corner -> center on the way out,
+        # so stored translations stay OME-correct.
+        raw_offset = tuple(o - vs / 2.0 for o, vs in zip(raw_offset, raw_voxel_size))
+
         # Scale float voxel sizes to integers for funlib compatibility
         scaled_vs, scale_factor = scale_voxel_size_to_integers(raw_voxel_size)
         self.original_voxel_size = raw_voxel_size

--- a/src/cellmap_analyze/util/voxel_size_utils.py
+++ b/src/cellmap_analyze/util/voxel_size_utils.py
@@ -76,14 +76,16 @@ def read_raw_voxel_size(ds):
     if "voxel_size" in attrs:
         return tuple(float(v) for v in attrs["voxel_size"])
 
+    scale_name = _array_scale_name(ds)
+
     # Check OME-Zarr multiscales on the array itself (rare but possible)
     if "multiscales" in attrs:
-        return _extract_ome_scale(attrs)
+        return _extract_ome_scale(attrs, scale_name)
 
     # Check OME-Zarr multiscales on parent group
     parent_attrs = _read_parent_attrs(ds)
     if parent_attrs and "multiscales" in parent_attrs:
-        return _extract_ome_scale(parent_attrs)
+        return _extract_ome_scale(parent_attrs, scale_name)
 
     # Check N5 pixelResolution
     if "pixelResolution" in attrs:
@@ -108,16 +110,18 @@ def read_raw_offset(ds):
     if "offset" in attrs:
         return tuple(float(v) for v in attrs["offset"])
 
+    scale_name = _array_scale_name(ds)
+
     # Check OME-Zarr multiscales on the array
     if "multiscales" in attrs:
-        translation = _extract_ome_translation(attrs)
+        translation = _extract_ome_translation(attrs, scale_name)
         if translation is not None:
             return translation
 
     # Check parent group for OME-Zarr
     parent_attrs = _read_parent_attrs(ds)
     if parent_attrs and "multiscales" in parent_attrs:
-        translation = _extract_ome_translation(parent_attrs)
+        translation = _extract_ome_translation(parent_attrs, scale_name)
         if translation is not None:
             return translation
 
@@ -125,21 +129,59 @@ def read_raw_offset(ds):
     return tuple(float(v) for v in ds.roi.offset)
 
 
-def _extract_ome_scale(attrs):
-    """Extract voxel size from OME-Zarr multiscales metadata."""
-    transforms = attrs["multiscales"][0]["datasets"][0]["coordinateTransformations"]
+def _select_ome_dataset(attrs, scale_name=None):
+    """Pick the multiscales ``datasets`` entry for the level being opened.
+
+    Each scale level (s0, s1, ...) carries its OWN scale + translation, so we
+    must match the opened array's leaf name (e.g. "s1") against the dataset
+    ``path``. Falls back to the first entry when the level can't be identified
+    (single-scale metadata, or a non-standard array name).
+    """
+    datasets = attrs["multiscales"][0]["datasets"]
+    if scale_name is not None:
+        for d in datasets:
+            if d.get("path") == scale_name:
+                return d
+    return datasets[0]
+
+
+def _extract_ome_scale(attrs, scale_name=None):
+    """Extract voxel size from OME-Zarr multiscales metadata for a given level."""
+    transforms = _select_ome_dataset(attrs, scale_name)["coordinateTransformations"]
     for t in transforms:
         if t["type"] == "scale":
             return tuple(float(v) for v in t["scale"])
     raise ValueError("No scale transform found in OME-Zarr multiscales metadata")
 
 
-def _extract_ome_translation(attrs):
-    """Extract offset from OME-Zarr multiscales metadata."""
-    transforms = attrs["multiscales"][0]["datasets"][0]["coordinateTransformations"]
+def _extract_ome_translation(attrs, scale_name=None):
+    """Extract offset from OME-Zarr multiscales metadata for a given level."""
+    transforms = _select_ome_dataset(attrs, scale_name)["coordinateTransformations"]
     for t in transforms:
         if t["type"] == "translation":
             return tuple(float(v) for v in t["translation"])
+    return None
+
+
+def _array_scale_name(ds):
+    """Leaf name of the array's location (e.g. "s1"), used to select the
+    matching OME multiscales dataset entry. Returns None if it can't be
+    determined (then callers fall back to the first multiscales entry)."""
+    try:
+        import os
+
+        array_name = getattr(ds.data, "name", None) or getattr(ds.data, "path", "")
+        array_name = str(array_name).strip("/")
+        if array_name:
+            return array_name.split("/")[-1]
+        store_root = getattr(getattr(ds.data, "store", None), "root", None)
+        if store_root:
+            s = str(store_root)
+            if s.startswith("file://"):
+                s = s[len("file://"):]
+            return os.path.basename(s.rstrip("/"))
+    except Exception:
+        pass
     return None
 
 

--- a/src/cellmap_analyze/util/zarr_io.py
+++ b/src/cellmap_analyze/util/zarr_io.py
@@ -200,12 +200,15 @@ def _read_voxel_size_offset(ds):
     scaled_vs, scale_factor = scale_voxel_size_to_integers(true_voxel_size)
     voxel_size = Coordinate(scaled_vs)
 
-    # The persisted offset is in true physical units (new convention) or
-    # already 0 in the overwhelming majority of cases; scale it to match the
-    # integer voxel_size, mirroring ImageDataInterface's own offset handling.
+    # The persisted offset / OME translation is the voxel CENTER of voxel
+    # [0,0,0]; convert it to the funlib CORNER (begin) by subtracting half a
+    # voxel before scaling, mirroring ImageDataInterface. The write path
+    # (create_multiscale_dataset) adds the half-voxel back so stored values
+    # stay OME-correct.
     if "offset" in attrs:
         offset = Coordinate(
-            int(round(float(v) * scale_factor)) for v in attrs["offset"]
+            int(round((float(v) - true_voxel_size[i] / 2.0) * scale_factor))
+            for i, v in enumerate(attrs["offset"])
         )
     else:
         offset = Coordinate(0 for _ in voxel_size)

--- a/src/cellmap_analyze/util/zarr_util.py
+++ b/src/cellmap_analyze/util/zarr_util.py
@@ -118,46 +118,41 @@ def create_multiscale_dataset(
         # Named dataset case: has a dataset name
         metadata_path = filename + "/" + dataset_base
 
-    # Write OME-Zarr metadata with the original (true) float voxel size
-    # so that other tools can read the correct physical coordinates.
-    # The scaled integer voxel_size is only used internally for funlib compatibility.
-    metadata_voxel_size = (
-        list(original_voxel_size) if original_voxel_size is not None else voxel_size
-    )
-    if original_voxel_size is not None:
-        # Convert scaled offset back to true physical coordinates
-        from cellmap_analyze.util.voxel_size_utils import scale_voxel_size_to_integers
+    # Persist the TRUE physical voxel size and offset (OME-NGFF translation) on
+    # the array attrs so external readers (neuroglancer, OME tools) get correct
+    # physical coordinates. The scaled integer voxel_size prepare_ds wrote is
+    # internal-only; cellmap-analyze re-derives the integer scaling on read
+    # (ImageDataInterface + _read_voxel_size_offset). voxel_size now holds the
+    # true value (no separate original_voxel_size attr).
+    from cellmap_analyze.util.voxel_size_utils import scale_voxel_size_to_integers
 
-        _, scale_factor = scale_voxel_size_to_integers(original_voxel_size)
-        metadata_translation = [
-            float(b) / scale_factor for b in total_roi.get_begin()
-        ]
-    else:
-        metadata_translation = total_roi.get_begin()
+    effective_voxel_size = (
+        list(original_voxel_size)
+        if original_voxel_size is not None
+        else list(voxel_size)
+    )
+    _, scale_factor = scale_voxel_size_to_integers(effective_voxel_size)
+    # total_roi.begin is the internal funlib CORNER (= OME center - vs/2).
+    # Convert corner -> OME center (+ vs/2) so the persisted translation/offset
+    # is the voxel CENTER, matching OME-NGFF and what the read path expects
+    # (it subtracts vs/2 back to the corner). Done for integer voxels too, so
+    # there is no fall-through that leaves a raw corner on disk.
+    metadata_translation = [
+        float(b) / scale_factor + ev / 2.0
+        for b, ev in zip(total_roi.get_begin(), effective_voxel_size)
+    ]
 
     write_multiscales_metadata(
         metadata_path,
         f"s{scale}",
-        metadata_voxel_size,
+        effective_voxel_size,
         metadata_translation,
         "nanometer",
         ["z", "y", "x"],
     )
 
-    # Persist the TRUE physical voxel_size and offset on the array attrs.
-    # prepare_ds wrote the funlib-scaled integer (needed to compute the array
-    # shape in integer world coords), but that value is internal-only — every
-    # external reader (neuroglancer, OME tools, anything reading voxel_size
-    # literally) expects physical units. cellmap-analyze re-derives the integer
-    # scaling in memory on read (ImageDataInterface + _read_voxel_size_offset),
-    # so overwriting the persisted attrs with the true values is safe for our
-    # own pipeline. We no longer write a separate original_voxel_size attr —
-    # voxel_size now holds the true value. (The readers still *accept* an
-    # original_voxel_size attr if present, so legacy datasets whose voxel_size
-    # holds the old scaled integer keep reading correctly.)
-    if original_voxel_size is not None:
-        ds.data.attrs["voxel_size"] = list(original_voxel_size)
-        ds.data.attrs["offset"] = list(metadata_translation)
+    ds.data.attrs["voxel_size"] = list(effective_voxel_size)
+    ds.data.attrs["offset"] = list(metadata_translation)
 
     return ds
 

--- a/tests/operations/test_image_data_interface.py
+++ b/tests/operations/test_image_data_interface.py
@@ -73,3 +73,60 @@ def test_image_data_interface_reflect(tmp_zarr, image_with_holes_filled):
         test_data,
         ground_truth,
     )
+
+
+def test_nonzero_translation_center_corner_convention(tmp_path, voxel_size):
+    """Regression for the OME voxel-CENTER convention with a NON-ZERO
+    translation (the rest of the suite only exercises translation 0).
+
+    The stored OME translation is the voxel CENTER of voxel [0,0,0]; internally
+    the IDI exposes the funlib CORNER (= translation - vs/2). Writing converts
+    corner -> center, so the stored translation round-trips, and measure reports
+    COMs at true OME centers.
+    """
+    from cellmap_analyze.util.zarr_util import create_multiscale_dataset
+    from cellmap_analyze.util.voxel_size_utils import scale_voxel_size_to_integers
+    from cellmap_analyze.analyze.measure import Measure
+    import zarr
+
+    vs = tuple(float(v) for v in voxel_size)
+    scaled_vs, sf = scale_voxel_size_to_integers(vs)
+    # Pick a clean integer corner (5 voxels in) so there is no rounding slack;
+    # the corresponding OME center is corner + vs/2 = 5.5 voxels.
+    corner_scaled = tuple(5 * s for s in scaled_vs)
+    expected_translation = tuple(c / sf + v / 2 for c, v in zip(corner_scaled, vs))
+
+    shape = (8, 8, 8)
+    total_roi = Roi(
+        Coordinate(corner_scaled), Coordinate(shape) * Coordinate(scaled_vs)
+    )
+    path = str(tmp_path / "data.zarr/seg")
+    ds = create_multiscale_dataset(
+        path,
+        dtype=np.uint8,
+        voxel_size=list(scaled_vs),
+        total_roi=total_roi,
+        write_size=Coordinate(shape) * Coordinate(scaled_vs),
+        original_voxel_size=list(vs),
+    )
+    idx = (1, 2, 3)
+    arr = np.zeros(shape, dtype=np.uint8)
+    arr[idx] = 1
+    ds.data[:] = arr
+
+    # stored OME translation is the CENTER
+    zattrs = dict(zarr.open_group(path, mode="r").attrs)
+    stored = zattrs["multiscales"][0]["datasets"][0]["coordinateTransformations"][
+        1
+    ]["translation"]
+    assert np.allclose(stored, expected_translation)
+
+    # IDI exposes the CORNER = translation - vs/2 (round-trips the corner)
+    idi = ImageDataInterface(f"{path}/s0")
+    assert tuple(idi.offset) == corner_scaled
+
+    # measure COM lands on the OME center of the object voxel: T + idx*vs
+    m = Measure(input_path=f"{path}/s0", output_path=str(tmp_path / "csvs"), num_workers=1)
+    m.measure()
+    expected_com = tuple(expected_translation[d] + idx[d] * vs[d] for d in range(3))
+    assert np.allclose(tuple(m.measurements[1].com), expected_com)

--- a/tests/operations/test_image_data_interface_non_integer.py
+++ b/tests/operations/test_image_data_interface_non_integer.py
@@ -512,8 +512,10 @@ class TestN5AnisotropicSwapAxes:
     def test_single_voxel_roi_z_axis(self, tmp_n5):
         """A 1-voxel-thick ROI in z should return shape 1 in that dimension."""
         idi = ImageDataInterface(tmp_n5)
-        # IDI voxel_size is now (131, 100, 100) in z,y,x; z-voxel = 131
-        roi = Roi(Coordinate(0, 0, 0), Coordinate(131, 1000, 1000))
+        # IDI voxel_size is now (131, 100, 100) in z,y,x; z-voxel = 131.
+        # Anchor at idi.roi.begin: with no OME translation the offset is treated
+        # as a voxel CENTER, so the grid-aligned corner is begin = -vs/2, not 0.
+        roi = Roi(idi.roi.begin, Coordinate(131, 1000, 1000))
         result = idi.to_ndarray_ts(roi)
         assert result.shape[0] == 1, (
             f"Expected 1 voxel in z, got {result.shape[0]} (shape={result.shape})"
@@ -522,8 +524,9 @@ class TestN5AnisotropicSwapAxes:
     def test_single_voxel_roi_x_axis(self, tmp_n5):
         """A 1-voxel-thick ROI in x should return shape 1 in that dimension."""
         idi = ImageDataInterface(tmp_n5)
-        # x-voxel = 100
-        roi = Roi(Coordinate(0, 0, 0), Coordinate(1310, 1000, 100))
+        # x-voxel = 100. Anchor at idi.roi.begin (= -vs/2) since the offset is
+        # treated as a voxel CENTER when no OME translation is present.
+        roi = Roi(idi.roi.begin, Coordinate(1310, 1000, 100))
         result = idi.to_ndarray_ts(roi)
         assert result.shape[2] == 1, (
             f"Expected 1 voxel in x, got {result.shape[2]} (shape={result.shape})"

--- a/tests/operations/test_skeletonize.py
+++ b/tests/operations/test_skeletonize.py
@@ -896,6 +896,78 @@ def test_skeletonize_seed_voxel_fallback(shared_tmpdir):
     assert df.loc[1, "Radius Std (nm)"] == 0.0
 
 
+def test_skeletonize_nonzero_translation_shifts_by_translation(shared_tmpdir):
+    """Regression for the OME voxel-CENTER convention in the skeletonize path.
+
+    The rest of the suite only exercises translation 0 (where the center<->corner
+    conversion cancels to a no-op). Here we skeletonize the SAME object in two
+    datasets that differ only by a non-zero OME translation, and assert the
+    resulting skeleton is identical up to a shift equal to that translation --
+    i.e. translation propagates with no half-voxel, sign, or doubling error.
+    """
+    from cellmap_analyze.util.zarr_util import create_multiscale_dataset
+    from funlib.geometry import Coordinate, Roi
+
+    vs = (2, 2, 2)          # isotropic -> no resampling; vs/2 = 1 (integer corner)
+    delta = 24              # isotropic corner shift in nm (== OME translation shift)
+
+    # Elongated rod (3x3 cross-section, 11 long) skeletonizes to a clean line.
+    seg = np.zeros((20, 20, 20), dtype=np.uint8)
+    seg[3:14, 9:12, 9:12] = 1
+    zc, yc, xc = np.where(seg)
+
+    def run(name, begin):
+        data_path = f"{shared_tmpdir}/{name}.zarr/seg"
+        total_roi = Roi(Coordinate(begin), Coordinate(seg.shape) * Coordinate(vs))
+        ds = create_multiscale_dataset(
+            data_path,
+            dtype=seg.dtype,
+            voxel_size=list(vs),
+            total_roi=total_roi,
+            write_size=Coordinate(seg.shape) * Coordinate(vs),
+            original_voxel_size=list(vs),
+        )
+        ds.data[:] = seg
+        # bbox CSV = OME centers of the object's min/max voxels, exactly what
+        # measure would emit for this dataset: (idx + 0.5)*vs + begin (sf == 1).
+        b = begin
+        csv_path = f"{shared_tmpdir}/{name}_bbox.csv"
+        pd.DataFrame([{
+            "Object ID": 1,
+            "MIN Z (nm)": (zc.min() + 0.5) * vs[0] + b[0],
+            "MIN Y (nm)": (yc.min() + 0.5) * vs[1] + b[1],
+            "MIN X (nm)": (xc.min() + 0.5) * vs[2] + b[2],
+            "MAX Z (nm)": (zc.max() + 0.5) * vs[0] + b[0],
+            "MAX Y (nm)": (yc.max() + 0.5) * vs[1] + b[1],
+            "MAX X (nm)": (xc.max() + 0.5) * vs[2] + b[2],
+        }]).set_index("Object ID").to_csv(csv_path)
+        out = f"{shared_tmpdir}/{name}_out"
+        Skeletonize(
+            segmentation_path=f"{data_path}/s0",
+            output_path=out,
+            csv_path=csv_path,
+            erosion=False,
+            min_branch_length_nm=0,
+            tolerance_nm=0,
+            num_workers=1,
+            sharded=False,
+        ).skeletonize()
+        verts, _ = CustomSkeleton.read_neuroglancer_skeleton(f"{out}/full/1")
+        return np.array(sorted(map(tuple, verts)))
+
+    verts_0 = run("skel_t0", (0, 0, 0))
+    verts_t = run("skel_tT", (delta, delta, delta))
+
+    assert len(verts_0) > 0, "expected a non-empty skeleton"
+    assert len(verts_0) == len(verts_t)
+    # The translated skeleton is the zero skeleton shifted by exactly delta.
+    assert np.allclose(verts_t, verts_0 + delta, atol=1e-6)
+    # And the zero skeleton sits on OME centers within the object's z bbox
+    # (MIN Z center = 3.5*2 = 7, MAX Z center = 13.5*2 = 27).
+    assert verts_0[:, 2].min() >= 7 - 1e-6
+    assert verts_0[:, 2].max() <= 27 + 1e-6
+
+
 def test_skeletonize_sharded_default(tmp_zarr, tmp_skeletonize_csv):
     """With sharded=True default, per-ID files are repacked into shard files
     and the info file picks up the sharding spec; one chunk should round-trip

--- a/tests/test_zarr_v3.py
+++ b/tests/test_zarr_v3.py
@@ -147,8 +147,9 @@ class TestZarrV2BackwardCompat:
         assert tuple(idi.voxel_size) == vs
         assert tuple(idi.roi.shape) == tuple(s * v for s, v in zip(shape, vs))
 
-        roi = Roi(Coordinate(0, 0, 0), Coordinate(shape) * Coordinate(vs))
-        read_data = idi.to_ndarray_ds(roi)
+        # Read the dataset's own ROI: the OME translation is the voxel CENTER,
+        # so the dataset corner is translation - vs/2, not the origin.
+        read_data = idi.to_ndarray_ds(idi.roi)
         assert np.all(read_data == 42)
 
     def test_read_v2_with_ome_metadata(self, tmp_path):
@@ -241,10 +242,10 @@ class TestZarrV2BackwardCompat:
         assert tuple(idi.original_voxel_size) == (16.0, 16.0, 16.0)
         assert idi.ds.data.shape == (10, 10, 10)
 
-        # Verify data round-trip
-        from funlib.geometry import Roi, Coordinate
-        roi = Roi(Coordinate(0, 0, 0), Coordinate(10, 10, 10) * idi.voxel_size)
-        read_data = idi.to_ndarray_ds(roi)
+        # Verify data round-trip. Read the dataset's own ROI: the OME
+        # translation is the voxel CENTER, so the corner is translation - vs/2,
+        # not the origin.
+        read_data = idi.to_ndarray_ds(idi.roi)
         assert np.array_equal(read_data, test_data)
 
     def test_v3_output_has_ome_ngff_metadata(self, tmp_path):

--- a/tests/test_zarr_v3.py
+++ b/tests/test_zarr_v3.py
@@ -326,3 +326,59 @@ class TestZarrV2BackwardCompat:
         assert not os.path.exists(os.path.join(s0_path, ".zarray")), (
             "Found .zarray (v2) in v3 container — format mismatch"
         )
+
+
+class TestMultiscaleLevelSelection:
+    """Each scale level (s0, s1, ...) carries its own scale + translation in the
+    OME multiscales metadata. Opening a non-s0 level of an external dataset
+    (no per-array attrs) must read THAT level's transform, not s0's."""
+
+    def _make_external_multiscale(self, root):
+        """Two-level OME multiscale on the parent group, arrays carry no
+        per-array voxel_size/offset attrs (pure OME, like external EM data)."""
+        import zarr
+
+        seg = os.path.join(root, "seg")
+        os.makedirs(seg)
+        json.dump({"zarr_format": 2}, open(os.path.join(root, ".zgroup"), "w"))
+        json.dump({"zarr_format": 2}, open(os.path.join(seg, ".zgroup"), "w"))
+        ome = {
+            "multiscales": [{
+                "axes": [{"name": a, "type": "space", "unit": "nanometer"} for a in "zyx"],
+                "datasets": [
+                    {"path": "s0", "coordinateTransformations": [
+                        {"scale": [4.0, 4.0, 4.0], "type": "scale"},
+                        {"translation": [0.0, 0.0, 0.0], "type": "translation"}]},
+                    {"path": "s1", "coordinateTransformations": [
+                        {"scale": [8.0, 8.0, 8.0], "type": "scale"},
+                        {"translation": [2.0, 2.0, 2.0], "type": "translation"}]},
+                ],
+                "name": "", "version": "0.4",
+            }]
+        }
+        json.dump(ome, open(os.path.join(seg, ".zattrs"), "w"))
+        for name, shp in [("s0", (20, 20, 20)), ("s1", (10, 10, 10))]:
+            a = zarr.open_array(
+                os.path.join(seg, name), mode="w", shape=shp, chunks=shp,
+                dtype="uint8", zarr_format=2,
+            )
+            a[:] = 1
+        return seg
+
+    def test_reads_per_level_scale_and_translation(self, tmp_path):
+        seg = self._make_external_multiscale(str(tmp_path / "ext.zarr"))
+
+        idi0 = ImageDataInterface(f"{seg}/s0")
+        assert tuple(idi0.voxel_size) == (4, 4, 4)
+        # translation 0 (center) -> corner = 0 - 4/2 = -2
+        assert tuple(idi0.offset) == (-2, -2, -2)
+
+        idi1 = ImageDataInterface(f"{seg}/s1")
+        # must pick up s1's scale, not s0's
+        assert tuple(idi1.voxel_size) == (8, 8, 8)
+        # translation 2 (center) -> corner = 2 - 8/2 = -2
+        assert tuple(idi1.offset) == (-2, -2, -2)
+
+        # Both levels share the same corner (-V_base/2) -- the OME pyramid
+        # invariant that keeps scales aligned.
+        assert tuple(idi0.offset) == tuple(idi1.offset)


### PR DESCRIPTION
@stuarteberg
## Summary

Two fixes for OME-NGFF coordinate handling that line up cellmap-analyze with the OME convention (translation = the voxel center) and remove a level-selection bug in the multiscale reader.

**1. Voxel-center convention via center↔corner conversion at the I/O boundary.** OME translation is the center of voxel [0,0,0]; funlib's `offset` is the corner. The code was using the translation directly as a corner — a `vs/2` mismatch that made measure COMs `+vs/2` high and broke cross-scale assignment at voxel boundaries. The read path (`ImageDataInterface`, `_read_voxel_size_offset`) now subtracts `vs/2` (center → corner); the write path (`create_multiscale_dataset`) adds it back (corner → center, so on-disk translations are unchanged). The integer-voxel branch is unified so it can't silently persist a raw corner.

- For cellmap-written / translation-0 data: completely a no-op (the write and read `vs/2` cancel; `idi.offset` stays 0; measure/assign/skeleton/contact byte-identical to before).
- For non-zero translations: measure COMs now land on the true OME center, and cross-scale assignment is correct at voxel boundaries (the old `floor((com-T)/vs)` shifted the grid by a half-voxel relative to OME — fine COMs near coarse-voxel edges could flip to a neighboring target voxel).
- Stored OME translations on disk are unchanged, so neuroglancer / external tools see no difference.

**2. Read the opened scale level's OME transform, not `datasets[0]`.** `_extract_ome_scale` / `_extract_ome_translation` hardcoded `datasets[0]`, so opening a non-s0 level of an external OME-zarr (scale only in the parent `multiscales`, no per-array attrs) read s0's scale and translation. They now match the opened array's leaf name (e.g. `s1`) against each `datasets[].path` and use that level's transform. Only affects external OME-zarr at non-s0 levels; cellmap-written zarr (per-array `voxel_size` attr), N5 (per-array `pixelResolution`), and s0 reads were already correct.

**Tests.** Existing 197 still pass. Adds 10 targeted regression tests for the cases the suite didn't cover:
- non-zero-translation IDI / measure contract (offset = corner, COM = OME center)
- skeletonize translation propagation (skeleton shifts by exactly the translation, no half-voxel / sign / doubling error)
- multiscale level selection (opening `s1` returns s1's scale + translation, not s0's)

Two existing zarr_v3 / N5-non-integer tests were updated: they read a hand-built `Roi((0,0,0), shape*vs)` from external datasets, which under the corrected convention is now half-voxel misaligned with the grid; they now read the dataset's own `idi.roi` (the canonical way to read a full dataset).