### PR TITLE
Bump version to 0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cellmap-analyze"
-version = "0.2.3"
+version = "0.2.4"
 description = "Code to perform analysis on segmentations like those produced by CellMap"
 readme = "README.md"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary
Patch release bundling everything that landed since v0.2.3:
- **#68** memory-aware wave scheduling for skeletonize (`dask_util` helpers, dtype-aware estimator, `safety_multiplier` knob)
- **#69** persist true physical voxel_size/offset on disk (drop the funlib-scaled integer; drop the `original_voxel_size` attr)
- **#70** treat OME translation as voxel center (convert center↔corner at I/O so measure/assign/cross-scale ops are OME-correct for non-zero translations); read the opened scale level's OME transform instead of `datasets[0]`