### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cellmap-analyze"
-version = "0.2.3"
+version = "0.3.0"
 description = "Code to perform analysis on segmentations like those produced by CellMap"
 readme = "README.md"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary
Minor bump for the OME-correctness release. Bundles everything since v0.2.3:
- **#68** memory-aware wave scheduling for skeletonize (new feature)
- **#69** persist true physical voxel_size/offset on disk (drops the funlib-scaled integer and the `original_voxel_size` attr — on-disk metadata format change)
- **#70** treat OME translation as the voxel center: convert center↔corner at I/O so measure/assign/cross-scale ops are OME-correct for non-zero translations; read the opened scale level's OME transform instead of `datasets[0]`

The minor bump reflects (a) a new feature, (b) a subtle on-disk format change for newly written datasets, and (c) an observable behavior change for users with non-zero-translation data (measure COMs shift by `vs/2`, cross-scale boundary assignments differ).