### PR TITLE
Prefer OME multiscales over per-array attrs; error on disagreement

### DIFF
--- a/src/cellmap_analyze/util/voxel_size_utils.py
+++ b/src/cellmap_analyze/util/voxel_size_utils.py
@@ -60,73 +60,158 @@ def compute_common_scale_factor(*scale_factors):
 def read_raw_voxel_size(ds):
     """Read the original float voxel_size from zarr/n5 attributes.
 
-    Reads directly from zarr attributes to avoid funlib.geometry.Coordinate
-    truncation. Checks multiple metadata formats.
+    Precedence: the OME-NGFF ``multiscales`` scale at the opened level is the
+    canonical source (it is the actual spec, and level-aware by construction).
+    Funlib-style per-array ``voxel_size`` attrs are accepted as a legacy
+    fallback. N5 ``pixelResolution`` and funlib's own parsed value follow.
+
+    If OME and the per-array ``voxel_size`` attr are BOTH present and
+    disagree, this raises ValueError -- silent precedence here is the exact
+    failure mode that lets stale per-array attrs override corrected group
+    metadata. Reconcile before downstream operations misread.
 
     Args:
-        ds: A funlib.persistence Array (returned by open_ds)
+        ds: A CellMapArray (returned by open_dataset).
 
     Returns:
         Tuple of floats representing the true voxel size.
     """
     attrs = dict(ds.data.attrs)
-
-    # funlib-style voxel_size attribute on the array. cellmap-analyze writes
-    # the TRUE physical voxel size here (see create_multiscale_dataset).
-    if "voxel_size" in attrs:
-        return tuple(float(v) for v in attrs["voxel_size"])
-
     scale_name = _array_scale_name(ds)
 
-    # Check OME-Zarr multiscales on the array itself (rare but possible)
-    if "multiscales" in attrs:
-        return _extract_ome_scale(attrs, scale_name)
+    ome_vs = _ome_scale_for(attrs, scale_name) or _ome_scale_for(
+        _read_parent_attrs(ds) or {}, scale_name
+    )
+    arr_vs = (
+        tuple(float(v) for v in attrs["voxel_size"])
+        if "voxel_size" in attrs
+        else None
+    )
 
-    # Check OME-Zarr multiscales on parent group
-    parent_attrs = _read_parent_attrs(ds)
-    if parent_attrs and "multiscales" in parent_attrs:
-        return _extract_ome_scale(parent_attrs, scale_name)
+    if ome_vs is not None and arr_vs is not None and not _values_match(ome_vs, arr_vs):
+        raise ValueError(
+            _conflict_msg(
+                ds,
+                "voxel_size",
+                "OME multiscales scale",
+                ome_vs,
+                "per-array voxel_size attr",
+                arr_vs,
+            )
+        )
 
-    # Check N5 pixelResolution
+    if ome_vs is not None:
+        return ome_vs
+    if arr_vs is not None:
+        return arr_vs
+
+    # N5 pixelResolution (legacy per-array fallback)
     if "pixelResolution" in attrs:
         return tuple(float(v) for v in attrs["pixelResolution"]["dimensions"])
 
-    # Fallback: use what funlib already parsed (may be truncated)
+    # Last-ditch fallback to whatever funlib already parsed
     return tuple(float(v) for v in ds.voxel_size)
 
 
 def read_raw_offset(ds):
-    """Read the original float offset from zarr/n5 attributes.
+    """Read the original float offset/translation from zarr/n5 attributes.
+
+    Same precedence and conflict semantics as :func:`read_raw_voxel_size`:
+    OME ``multiscales`` translation at the opened level is canonical, the
+    per-array ``offset`` attr is legacy fallback, and a disagreement between
+    the two raises ValueError.
 
     Args:
-        ds: A funlib.persistence Array (returned by open_ds)
+        ds: A CellMapArray (returned by open_dataset).
 
     Returns:
-        Tuple of floats representing the true offset.
+        Tuple of floats representing the stored offset/translation
+        (per OME-NGFF: the voxel CENTER of voxel [0,0,0]).
     """
     attrs = dict(ds.data.attrs)
-
-    # Check funlib-style offset attribute
-    if "offset" in attrs:
-        return tuple(float(v) for v in attrs["offset"])
-
     scale_name = _array_scale_name(ds)
 
-    # Check OME-Zarr multiscales on the array
-    if "multiscales" in attrs:
-        translation = _extract_ome_translation(attrs, scale_name)
-        if translation is not None:
-            return translation
+    ome_tr = _ome_translation_for(attrs, scale_name) or _ome_translation_for(
+        _read_parent_attrs(ds) or {}, scale_name
+    )
+    arr_off = (
+        tuple(float(v) for v in attrs["offset"]) if "offset" in attrs else None
+    )
 
-    # Check parent group for OME-Zarr
-    parent_attrs = _read_parent_attrs(ds)
-    if parent_attrs and "multiscales" in parent_attrs:
-        translation = _extract_ome_translation(parent_attrs, scale_name)
-        if translation is not None:
-            return translation
+    if ome_tr is not None and arr_off is not None and not _values_match(ome_tr, arr_off):
+        raise ValueError(
+            _conflict_msg(
+                ds,
+                "translation/offset",
+                "OME multiscales translation",
+                ome_tr,
+                "per-array offset attr",
+                arr_off,
+            )
+        )
 
-    # Fallback
+    if ome_tr is not None:
+        return ome_tr
+    if arr_off is not None:
+        return arr_off
+
     return tuple(float(v) for v in ds.roi.offset)
+
+
+def _ome_scale_for(attrs, scale_name):
+    if not attrs or "multiscales" not in attrs:
+        return None
+    try:
+        return _extract_ome_scale(attrs, scale_name)
+    except (ValueError, KeyError, IndexError, TypeError):
+        return None
+
+
+def _ome_translation_for(attrs, scale_name):
+    if not attrs or "multiscales" not in attrs:
+        return None
+    try:
+        return _extract_ome_translation(attrs, scale_name)
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+def _values_match(a, b, atol=1e-6):
+    """Element-wise float compare with absolute tolerance; length-aware."""
+    if a is None or b is None:
+        return True
+    try:
+        a = tuple(float(v) for v in a)
+        b = tuple(float(v) for v in b)
+    except (TypeError, ValueError):
+        return False
+    if len(a) != len(b):
+        return False
+    return all(abs(x - y) <= atol for x, y in zip(a, b))
+
+
+def _conflict_msg(ds, kind, name_a, val_a, name_b, val_b):
+    return (
+        f"Metadata conflict on {kind} at {_ds_path(ds)}:\n"
+        f"  {name_a}: {list(val_a)}\n"
+        f"  {name_b}: {list(val_b)}\n"
+        f"Fix one to match the other (OME-NGFF convention: voxel CENTERS), "
+        f"or delete the stale attr."
+    )
+
+
+def _ds_path(ds):
+    """Best-effort path string for diagnostic messages."""
+    try:
+        store_root = getattr(getattr(ds.data, "store", None), "root", None)
+        if store_root:
+            s = str(store_root)
+            if s.startswith("file://"):
+                s = s[len("file://"):]
+            return s.rstrip("/")
+        return getattr(ds.data, "name", None) or getattr(ds.data, "path", "?")
+    except Exception:
+        return "?"
 
 
 def _select_ome_dataset(attrs, scale_name=None):

--- a/tests/test_zarr_v3.py
+++ b/tests/test_zarr_v3.py
@@ -382,3 +382,142 @@ class TestMultiscaleLevelSelection:
         # Both levels share the same corner (-V_base/2) -- the OME pyramid
         # invariant that keeps scales aligned.
         assert tuple(idi0.offset) == tuple(idi1.offset)
+
+
+class TestMetadataPrecedence:
+    """OME multiscales is the canonical source for voxel_size / translation;
+    funlib-style per-array attrs are accepted as a legacy fallback. When both
+    are present and they DISAGREE, reading must raise loudly -- silent
+    precedence in this case is exactly how stale per-array attrs can override
+    a corrected group-level OME and silently misplace downstream operations.
+    """
+
+    def _make_group_with_array(
+        self, root, ome=None, per_array=None, vs=(8, 8, 8), shape=(4, 4, 4)
+    ):
+        """Build a v2 zarr group at ``root`` with a single child array ``s0``.
+
+        ``ome``: dict to write as the group's .zattrs (typically multiscales).
+        ``per_array``: dict to write as the s0 array's .zattrs.
+        """
+        import zarr
+
+        os.makedirs(root)
+        json.dump({"zarr_format": 2}, open(os.path.join(root, ".zgroup"), "w"))
+        if ome is not None:
+            json.dump(ome, open(os.path.join(root, ".zattrs"), "w"))
+        a = zarr.open_array(
+            os.path.join(root, "s0"),
+            mode="w",
+            shape=shape,
+            chunks=shape,
+            dtype="uint8",
+            zarr_format=2,
+        )
+        a[:] = 1
+        if per_array is not None:
+            # zarr v2 writes .zattrs automatically when you set attrs; do it
+            # explicitly so we control exactly what lands on disk.
+            json.dump(
+                per_array, open(os.path.join(root, "s0", ".zattrs"), "w")
+            )
+        return os.path.join(root, "s0")
+
+    def _ome(self, vs=(8.0, 8.0, 8.0), trans=(0.0, 0.0, 0.0)):
+        return {
+            "multiscales": [
+                {
+                    "axes": [
+                        {"name": a, "type": "space", "unit": "nanometer"}
+                        for a in "zyx"
+                    ],
+                    "datasets": [
+                        {
+                            "path": "s0",
+                            "coordinateTransformations": [
+                                {"scale": list(vs), "type": "scale"},
+                                {"translation": list(trans), "type": "translation"},
+                            ],
+                        }
+                    ],
+                    "name": "",
+                    "version": "0.4",
+                }
+            ]
+        }
+
+    def test_ome_only_returns_ome_values(self, tmp_path):
+        """No per-array attrs at all -> OME is read."""
+        s0 = self._make_group_with_array(
+            str(tmp_path / "ome_only.zarr"),
+            ome=self._ome(vs=(8.0, 8.0, 8.0), trans=(4.0, 4.0, 4.0)),
+            per_array=None,
+        )
+        idi = ImageDataInterface(s0)
+        assert tuple(idi.voxel_size) == (8, 8, 8)
+        # corner = translation - vs/2 = 4 - 4 = 0
+        assert tuple(idi.offset) == (0, 0, 0)
+
+    def test_per_array_only_returns_per_array_values(self, tmp_path):
+        """No OME multiscales -> falls back to per-array attrs."""
+        s0 = self._make_group_with_array(
+            str(tmp_path / "attr_only.zarr"),
+            ome=None,
+            per_array={"voxel_size": [8.0, 8.0, 8.0], "offset": [4.0, 4.0, 4.0]},
+        )
+        idi = ImageDataInterface(s0)
+        assert tuple(idi.voxel_size) == (8, 8, 8)
+        assert tuple(idi.offset) == (0, 0, 0)
+
+    def test_both_consistent_succeeds(self, tmp_path):
+        """OME and per-array attrs both present and EQUAL -> no error, value
+        is returned (this is what cellmap-written datasets look like)."""
+        s0 = self._make_group_with_array(
+            str(tmp_path / "consistent.zarr"),
+            ome=self._ome(vs=(8.0, 8.0, 8.0), trans=(4.0, 4.0, 4.0)),
+            per_array={"voxel_size": [8.0, 8.0, 8.0], "offset": [4.0, 4.0, 4.0]},
+        )
+        idi = ImageDataInterface(s0)
+        assert tuple(idi.voxel_size) == (8, 8, 8)
+        assert tuple(idi.offset) == (0, 0, 0)
+
+    def test_voxel_size_conflict_raises(self, tmp_path):
+        """OME scale and per-array voxel_size disagree -> ValueError that
+        names BOTH values so the user can reconcile."""
+        s0 = self._make_group_with_array(
+            str(tmp_path / "vs_conflict.zarr"),
+            ome=self._ome(vs=(16.0, 16.0, 16.0), trans=(6.0, 6.0, 6.0)),
+            per_array={"voxel_size": [8.0, 8.0, 8.0], "offset": [6.0, 6.0, 6.0]},
+        )
+        with pytest.raises(ValueError) as exc:
+            ImageDataInterface(s0)
+        msg = str(exc.value)
+        assert "voxel_size" in msg
+        assert "16" in msg and "8" in msg
+        assert "OME" in msg
+
+    def test_translation_conflict_raises(self, tmp_path):
+        """OME translation and per-array offset disagree -> ValueError."""
+        s0 = self._make_group_with_array(
+            str(tmp_path / "tr_conflict.zarr"),
+            ome=self._ome(vs=(16.0, 16.0, 16.0), trans=(6.0, 6.0, 6.0)),
+            per_array={"voxel_size": [16.0, 16.0, 16.0], "offset": [0.0, 0.0, 0.0]},
+        )
+        with pytest.raises(ValueError) as exc:
+            ImageDataInterface(s0)
+        msg = str(exc.value)
+        assert "translation" in msg or "offset" in msg
+        assert "6" in msg and "0" in msg
+        assert "OME" in msg
+
+    def test_conflict_message_includes_path(self, tmp_path):
+        """The error message names the dataset path for diagnosis."""
+        target = str(tmp_path / "named.zarr")
+        s0 = self._make_group_with_array(
+            target,
+            ome=self._ome(vs=(16.0, 16.0, 16.0), trans=(6.0, 6.0, 6.0)),
+            per_array={"voxel_size": [16.0, 16.0, 16.0], "offset": [0.0, 0.0, 0.0]},
+        )
+        with pytest.raises(ValueError) as exc:
+            ImageDataInterface(s0)
+        assert "named.zarr" in str(exc.value)


### PR DESCRIPTION
## Summary

`read_raw_voxel_size` and `read_raw_offset` used to consult the funlib-style per-array `voxel_size` / `offset` attrs first and fall back to the OME-NGFF multiscales translation/scale at the parent group. That gave **stale per-array attrs silent precedence over corrected group metadata** — fixing only the OME translation on a dataset that already has `offset: [0,0,0]` on `s0/.zattrs` was invisible to cellmap-analyze while neuroglancer correctly read the OME fix. The two tools would silently disagree on the same data.

This PR flips the precedence so the OME `multiscales` entry for the opened level is the canonical source, and the per-array attrs are the legacy fallback. If **both** are present and **disagree**, the read raises `ValueError`, naming the dataset path and both values, so the metadata can be reconciled before anything silently misreads.

### Precedence (new)
1. OME `multiscales` translation/scale at the opened level (array-level first, then parent group) — canonical.
2. Per-array `voxel_size` / `offset` attr — legacy fallback (funlib convention).
3. N5 `pixelResolution` — N5 legacy fallback.
4. Funlib's already-parsed `ds.voxel_size` / `ds.roi.offset` — last-ditch.

### Conflict behavior
If step 1 and step 2 are both present and the values differ, raise:
```
Metadata conflict on voxel_size at /path/to/seg/s0:
  OME multiscales scale: [16.0, 16.0, 16.0]
  per-array voxel_size attr: [8.0, 8.0, 8.0]
Fix one to match the other (OME-NGFF convention: voxel CENTERS), or delete the stale attr.
```

### Backward compatibility
Cellmap-written datasets (current and pre-v0.3.0) write both attrs to the same value, so they never trigger the conflict — they go through step 1 and get the same number they used to from step 2. The only behavioral change is for datasets where a writer set both attrs to *different* values: previously cellmap silently picked one, now it errors and tells the user which is which.

### Tests added (6, all green; full suite 213 passing)
- OME-only metadata → returns OME values.
- Per-array-only metadata → returns per-array values (legacy fallback).
- Both present and consistent → no error, value returned.
- Voxel-size conflict → `ValueError` mentioning both values and "OME".
- Translation conflict → `ValueError` mentioning both values and "OME".
- Conflict message includes the dataset path.