### PR TITLE
Bake skeleton metrics into segment_properties by default

### DIFF
--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -246,7 +246,9 @@ class Skeletonize(ComputeConfigMixin):
         self.peak_bytes_per_voxel = float(peak_bytes_per_voxel)
         self.memory_safety_multiplier = float(memory_safety_multiplier)
         self.memory_fraction = float(memory_fraction)
-        self.skeleton_properties = bool(skeleton_properties)
+        self.skeleton_properties = self._normalize_skeleton_properties(
+            skeleton_properties
+        )
 
         # Load CSV with bounding box info
         self.bbox_df = pd.read_csv(csv_path, index_col=0)
@@ -566,13 +568,84 @@ class Skeletonize(ComputeConfigMixin):
             # properties at the end of skeletonize().
             self._write_segment_properties_info(subdir, metrics_by_id=None)
 
+    # Per-ID skeleton metrics that can be baked into the neuroglancer
+    # segment_properties as sortable side-panel columns. The defaults are the
+    # two that triage best (how complex / how long); radius stats are opt-in.
+    _SKELETON_PROPERTY_DEFS = {
+        "num_branches": {
+            "data_type": "int32",
+            "description": "Number of skeleton branches",
+            "cast": int,
+            "default": 0,
+        },
+        "longest_shortest_path_nm": {
+            "data_type": "float32",
+            "description": "Longest shortest path through the skeleton (nm)",
+            "cast": float,
+            "default": 0.0,
+        },
+        "radius_mean_nm": {
+            "data_type": "float32",
+            "description": "Mean skeleton radius from EDT (nm)",
+            "cast": float,
+            "default": 0.0,
+        },
+        "radius_std_nm": {
+            "data_type": "float32",
+            "description": "Std of skeleton radius (nm)",
+            "cast": float,
+            "default": 0.0,
+        },
+    }
+    DEFAULT_SKELETON_PROPERTIES = (
+        "num_branches",
+        "longest_shortest_path_nm",
+    )
+    ALL_SKELETON_PROPERTIES = tuple(_SKELETON_PROPERTY_DEFS.keys())
+
+    @classmethod
+    def _normalize_skeleton_properties(cls, value):
+        """Normalize the user-facing ``skeleton_properties`` argument to a
+        list of metric keys to emit.
+
+        - ``True`` (default) -> ``DEFAULT_SKELETON_PROPERTIES`` (num_branches,
+          longest_shortest_path_nm). Triage-first; not the full set.
+        - ``False`` / ``None`` -> ``[]`` (label only, legacy behavior).
+        - ``"all"`` -> every metric in ``ALL_SKELETON_PROPERTIES``.
+        - ``list``/``tuple`` of metric keys -> exactly those, validated.
+        """
+        if value is True:
+            return list(cls.DEFAULT_SKELETON_PROPERTIES)
+        if value is False or value is None:
+            return []
+        if isinstance(value, str):
+            if value == "all":
+                return list(cls.ALL_SKELETON_PROPERTIES)
+            raise ValueError(
+                f"skeleton_properties string must be 'all', got {value!r}; "
+                f"valid keys: {cls.ALL_SKELETON_PROPERTIES}"
+            )
+        if isinstance(value, (list, tuple, set)):
+            keys = list(value)
+            unknown = [k for k in keys if k not in cls._SKELETON_PROPERTY_DEFS]
+            if unknown:
+                raise ValueError(
+                    f"unknown skeleton_properties: {unknown}; valid keys: "
+                    f"{cls.ALL_SKELETON_PROPERTIES}"
+                )
+            return keys
+        raise TypeError(
+            f"skeleton_properties must be bool, 'all', or a list/tuple of "
+            f"metric keys, got {type(value).__name__}"
+        )
+
     def _write_segment_properties_info(self, subdir, metrics_by_id=None):
         """Write the segment_properties/info file for a subdir.
 
-        If ``metrics_by_id`` is provided (and ``self.skeleton_properties``),
-        bake per-ID skeleton metrics into the file as ``number`` properties so
-        they surface in the neuroglancer side panel (sortable columns:
-        Number of Branches, Longest Shortest Path, Radius Mean/Std).
+        If ``metrics_by_id`` is provided and ``self.skeleton_properties`` lists
+        any metric keys, bake those per-ID skeleton metrics into the file as
+        ``number`` properties so they surface as sortable columns in the
+        neuroglancer side panel.
         """
         segment_ids = [str(int(i)) for i in self.ids]
         properties = [
@@ -583,52 +656,31 @@ class Skeletonize(ComputeConfigMixin):
             }
         ]
         if self.skeleton_properties and metrics_by_id:
-            def col(key, default):
-                vals = []
+            for key in self.skeleton_properties:
+                spec = self._SKELETON_PROPERTY_DEFS[key]
+                default = spec["default"]
+                cast = spec["cast"]
+                values = []
                 for i in self.ids:
                     v = metrics_by_id.get(int(i), {}).get(key, default)
-                    # JSON has no NaN; render missing/NaN as 0 so neuroglancer
-                    # doesn't choke and so sortable columns degrade gracefully.
+                    # JSON has no NaN; render missing/NaN as the default so
+                    # neuroglancer doesn't choke and sortable columns degrade
+                    # gracefully (Lee's-wiped objects sit at one end).
                     try:
                         if v != v:  # NaN check
                             v = default
                     except TypeError:
                         v = default
-                    vals.append(v)
-                return vals
-
-            properties.extend(
-                [
+                    values.append(cast(v))
+                properties.append(
                     {
-                        "id": "num_branches",
+                        "id": key,
                         "type": "number",
-                        "data_type": "int32",
-                        "description": "Number of skeleton branches",
-                        "values": [int(v) for v in col("num_branches", 0)],
-                    },
-                    {
-                        "id": "longest_shortest_path_nm",
-                        "type": "number",
-                        "data_type": "float32",
-                        "description": "Longest shortest path through the skeleton (nm)",
-                        "values": [float(v) for v in col("longest_shortest_path_nm", 0.0)],
-                    },
-                    {
-                        "id": "radius_mean_nm",
-                        "type": "number",
-                        "data_type": "float32",
-                        "description": "Mean skeleton radius from EDT (nm)",
-                        "values": [float(v) for v in col("radius_mean_nm", 0.0)],
-                    },
-                    {
-                        "id": "radius_std_nm",
-                        "type": "number",
-                        "data_type": "float32",
-                        "description": "Std of skeleton radius (nm)",
-                        "values": [float(v) for v in col("radius_std_nm", 0.0)],
-                    },
-                ]
-            )
+                        "data_type": spec["data_type"],
+                        "description": spec["description"],
+                        "values": values,
+                    }
+                )
 
         info = {
             "@type": "neuroglancer_segment_properties",

--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -166,6 +166,7 @@ class Skeletonize(ComputeConfigMixin):
         peak_bytes_per_voxel=6.63,
         memory_safety_multiplier=2.0,
         memory_fraction=0.60,
+        skeleton_properties=True,
     ):
         """
         Skeletonize a segmentation, parallelized over IDs.
@@ -245,6 +246,7 @@ class Skeletonize(ComputeConfigMixin):
         self.peak_bytes_per_voxel = float(peak_bytes_per_voxel)
         self.memory_safety_multiplier = float(memory_safety_multiplier)
         self.memory_fraction = float(memory_fraction)
+        self.skeleton_properties = bool(skeleton_properties)
 
         # Load CSV with bounding box info
         self.bbox_df = pd.read_csv(csv_path, index_col=0)
@@ -559,30 +561,84 @@ class Skeletonize(ComputeConfigMixin):
                 json.dump(info, f)
             logger.info(f"Wrote neuroglancer info file to {info_path}")
 
-            # Write segment_properties info file
-            segment_ids = [str(id_val) for id_val in self.ids]
-            segment_properties_info = {
-                "@type": "neuroglancer_segment_properties",
-                "inline": {
-                    "ids": segment_ids,
-                    "properties": [
-                        {
-                            "id": "label",
-                            "type": "label",
-                            "values": ["" for _ in segment_ids],
-                        }
-                    ],
-                },
-            }
+            # Initial (metrics-free) segment_properties so the layer is valid
+            # even before metrics are computed. We rewrite it with the numeric
+            # properties at the end of skeletonize().
+            self._write_segment_properties_info(subdir, metrics_by_id=None)
 
-            segment_properties_path = (
-                f"{self.output_path}/{subdir}/segment_properties/info"
+    def _write_segment_properties_info(self, subdir, metrics_by_id=None):
+        """Write the segment_properties/info file for a subdir.
+
+        If ``metrics_by_id`` is provided (and ``self.skeleton_properties``),
+        bake per-ID skeleton metrics into the file as ``number`` properties so
+        they surface in the neuroglancer side panel (sortable columns:
+        Number of Branches, Longest Shortest Path, Radius Mean/Std).
+        """
+        segment_ids = [str(int(i)) for i in self.ids]
+        properties = [
+            {
+                "id": "label",
+                "type": "label",
+                "values": ["" for _ in segment_ids],
+            }
+        ]
+        if self.skeleton_properties and metrics_by_id:
+            def col(key, default):
+                vals = []
+                for i in self.ids:
+                    v = metrics_by_id.get(int(i), {}).get(key, default)
+                    # JSON has no NaN; render missing/NaN as 0 so neuroglancer
+                    # doesn't choke and so sortable columns degrade gracefully.
+                    try:
+                        if v != v:  # NaN check
+                            v = default
+                    except TypeError:
+                        v = default
+                    vals.append(v)
+                return vals
+
+            properties.extend(
+                [
+                    {
+                        "id": "num_branches",
+                        "type": "number",
+                        "data_type": "int32",
+                        "description": "Number of skeleton branches",
+                        "values": [int(v) for v in col("num_branches", 0)],
+                    },
+                    {
+                        "id": "longest_shortest_path_nm",
+                        "type": "number",
+                        "data_type": "float32",
+                        "description": "Longest shortest path through the skeleton (nm)",
+                        "values": [float(v) for v in col("longest_shortest_path_nm", 0.0)],
+                    },
+                    {
+                        "id": "radius_mean_nm",
+                        "type": "number",
+                        "data_type": "float32",
+                        "description": "Mean skeleton radius from EDT (nm)",
+                        "values": [float(v) for v in col("radius_mean_nm", 0.0)],
+                    },
+                    {
+                        "id": "radius_std_nm",
+                        "type": "number",
+                        "data_type": "float32",
+                        "description": "Std of skeleton radius (nm)",
+                        "values": [float(v) for v in col("radius_std_nm", 0.0)],
+                    },
+                ]
             )
-            with open(segment_properties_path, "w") as f:
-                json.dump(segment_properties_info, f)
-            logger.info(
-                f"Wrote segment_properties info file to {segment_properties_path}"
-            )
+
+        info = {
+            "@type": "neuroglancer_segment_properties",
+            "inline": {"ids": segment_ids, "properties": properties},
+        }
+        path = f"{self.output_path}/{subdir}/segment_properties/info"
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(info, f, allow_nan=False)
+        logger.info(f"Wrote segment_properties info file to {path}")
 
     def _estimate_peak_bytes(self, id_value):
         """Estimate per-ID peak RSS from the cached bbox row.
@@ -687,6 +743,13 @@ class Skeletonize(ComputeConfigMixin):
             self._pack_shards_from_metrics(all_metrics)
 
         self._write_skeleton_csv(all_metrics)
+
+        # Rewrite segment_properties with the per-ID metrics so they show up
+        # as sortable columns in the neuroglancer side panel.
+        if self.skeleton_properties:
+            metrics_by_id = {int(m["id"]): m for m in all_metrics}
+            for subdir in ("full", "simplified"):
+                self._write_segment_properties_info(subdir, metrics_by_id)
 
         logger.info("Skeletonization complete")
 

--- a/tests/operations/test_skeletonize.py
+++ b/tests/operations/test_skeletonize.py
@@ -1035,3 +1035,80 @@ def test_skeletonize_backward_compat_erosion_false(tmp_zarr, tmp_skeletonize_csv
 
     for id_val in [1, 2, 3, 4, 5, 6, 7, 8]:
         assert os.path.exists(f"{output_path}/full/{id_val}")
+
+
+def _read_seg_props(output_path, subdir="full"):
+    with open(f"{output_path}/{subdir}/segment_properties/info") as f:
+        return json.load(f)
+
+
+def test_skeletonize_segment_properties_default(tmp_zarr, tmp_skeletonize_csv):
+    """By default the segment_properties/info bakes in the per-ID skeleton
+    metrics (num_branches, longest_shortest_path_nm, radius_mean/std_nm) so
+    neuroglancer can show them as sortable columns in the side panel."""
+    output_path = tmp_zarr + "/test_skeletonize_segprops_default"
+    Skeletonize(
+        segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+        output_path=output_path,
+        csv_path=tmp_skeletonize_csv,
+        erosion=False,
+        min_branch_length_nm=0,
+        tolerance_nm=0,
+        num_workers=1,
+        sharded=False,
+    ).skeletonize()
+
+    expected_ids = {"1", "2", "3", "4", "5", "6", "7", "8"}
+    expected_metric_ids = {
+        "num_branches",
+        "longest_shortest_path_nm",
+        "radius_mean_nm",
+        "radius_std_nm",
+    }
+
+    for subdir in ("full", "simplified"):
+        seg = _read_seg_props(output_path, subdir)
+        assert seg["@type"] == "neuroglancer_segment_properties"
+        ids = seg["inline"]["ids"]
+        assert set(ids) == expected_ids
+        n = len(ids)
+        props = {p["id"]: p for p in seg["inline"]["properties"]}
+        # label property still present
+        assert "label" in props and props["label"]["type"] == "label"
+        # the four metric properties present with the right types and length
+        assert expected_metric_ids.issubset(props.keys())
+        for k in expected_metric_ids:
+            p = props[k]
+            assert p["type"] == "number"
+            assert p["data_type"] in ("int32", "float32")
+            assert len(p["values"]) == n
+            assert "description" in p
+
+        # ID 5 (the cross shape) gets real metrics under no-erosion.
+        i5 = ids.index("5")
+        assert props["num_branches"]["values"][i5] >= 3
+        assert props["longest_shortest_path_nm"]["values"][i5] > 0.0
+        assert props["radius_mean_nm"]["values"][i5] > 0.0
+
+
+def test_skeletonize_segment_properties_opt_out(tmp_zarr, tmp_skeletonize_csv):
+    """skeleton_properties=False keeps only the label property (legacy
+    behavior); the four metric columns are not written."""
+    output_path = tmp_zarr + "/test_skeletonize_segprops_optout"
+    Skeletonize(
+        segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+        output_path=output_path,
+        csv_path=tmp_skeletonize_csv,
+        erosion=False,
+        min_branch_length_nm=0,
+        tolerance_nm=0,
+        num_workers=1,
+        sharded=False,
+        skeleton_properties=False,
+    ).skeletonize()
+
+    seg = _read_seg_props(output_path, "full")
+    ids_in_props = {p["id"] for p in seg["inline"]["properties"]}
+    assert ids_in_props == {"label"}, (
+        f"expected only 'label' property when opted out, got {ids_in_props}"
+    )

--- a/tests/operations/test_skeletonize.py
+++ b/tests/operations/test_skeletonize.py
@@ -1043,9 +1043,8 @@ def _read_seg_props(output_path, subdir="full"):
 
 
 def test_skeletonize_segment_properties_default(tmp_zarr, tmp_skeletonize_csv):
-    """By default the segment_properties/info bakes in the per-ID skeleton
-    metrics (num_branches, longest_shortest_path_nm, radius_mean/std_nm) so
-    neuroglancer can show them as sortable columns in the side panel."""
+    """The default subset is the two triage-first metrics: num_branches and
+    longest_shortest_path_nm. radius_* are opt-in."""
     output_path = tmp_zarr + "/test_skeletonize_segprops_default"
     Skeletonize(
         segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
@@ -1059,41 +1058,77 @@ def test_skeletonize_segment_properties_default(tmp_zarr, tmp_skeletonize_csv):
     ).skeletonize()
 
     expected_ids = {"1", "2", "3", "4", "5", "6", "7", "8"}
-    expected_metric_ids = {
+    default_metrics = {"num_branches", "longest_shortest_path_nm"}
+
+    for subdir in ("full", "simplified"):
+        seg = _read_seg_props(output_path, subdir)
+        ids = seg["inline"]["ids"]
+        assert set(ids) == expected_ids
+        n = len(ids)
+        props = {p["id"]: p for p in seg["inline"]["properties"]}
+        assert "label" in props
+        # exactly the two default metrics — radius_* not included
+        assert set(props.keys()) - {"label"} == default_metrics
+        for k in default_metrics:
+            p = props[k]
+            assert p["type"] == "number"
+            assert p["data_type"] in ("int32", "float32")
+            assert len(p["values"]) == n
+
+        i5 = ids.index("5")
+        assert props["num_branches"]["values"][i5] >= 3
+        assert props["longest_shortest_path_nm"]["values"][i5] > 0.0
+
+
+def test_skeletonize_segment_properties_all(tmp_zarr, tmp_skeletonize_csv):
+    """skeleton_properties='all' includes radius_mean_nm and radius_std_nm too."""
+    output_path = tmp_zarr + "/test_skeletonize_segprops_all"
+    Skeletonize(
+        segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+        output_path=output_path,
+        csv_path=tmp_skeletonize_csv,
+        erosion=False,
+        min_branch_length_nm=0,
+        tolerance_nm=0,
+        num_workers=1,
+        sharded=False,
+        skeleton_properties="all",
+    ).skeletonize()
+
+    seg = _read_seg_props(output_path, "full")
+    props = {p["id"]: p for p in seg["inline"]["properties"]}
+    expected = {
+        "label",
         "num_branches",
         "longest_shortest_path_nm",
         "radius_mean_nm",
         "radius_std_nm",
     }
+    assert set(props.keys()) == expected
 
-    for subdir in ("full", "simplified"):
-        seg = _read_seg_props(output_path, subdir)
-        assert seg["@type"] == "neuroglancer_segment_properties"
-        ids = seg["inline"]["ids"]
-        assert set(ids) == expected_ids
-        n = len(ids)
-        props = {p["id"]: p for p in seg["inline"]["properties"]}
-        # label property still present
-        assert "label" in props and props["label"]["type"] == "label"
-        # the four metric properties present with the right types and length
-        assert expected_metric_ids.issubset(props.keys())
-        for k in expected_metric_ids:
-            p = props[k]
-            assert p["type"] == "number"
-            assert p["data_type"] in ("int32", "float32")
-            assert len(p["values"]) == n
-            assert "description" in p
 
-        # ID 5 (the cross shape) gets real metrics under no-erosion.
-        i5 = ids.index("5")
-        assert props["num_branches"]["values"][i5] >= 3
-        assert props["longest_shortest_path_nm"]["values"][i5] > 0.0
-        assert props["radius_mean_nm"]["values"][i5] > 0.0
+def test_skeletonize_segment_properties_explicit_list(tmp_zarr, tmp_skeletonize_csv):
+    """Passing an explicit list emits exactly those properties."""
+    output_path = tmp_zarr + "/test_skeletonize_segprops_list"
+    Skeletonize(
+        segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+        output_path=output_path,
+        csv_path=tmp_skeletonize_csv,
+        erosion=False,
+        min_branch_length_nm=0,
+        tolerance_nm=0,
+        num_workers=1,
+        sharded=False,
+        skeleton_properties=["radius_mean_nm"],
+    ).skeletonize()
+
+    seg = _read_seg_props(output_path, "full")
+    props = {p["id"]: p for p in seg["inline"]["properties"]}
+    assert set(props.keys()) == {"label", "radius_mean_nm"}
 
 
 def test_skeletonize_segment_properties_opt_out(tmp_zarr, tmp_skeletonize_csv):
-    """skeleton_properties=False keeps only the label property (legacy
-    behavior); the four metric columns are not written."""
+    """skeleton_properties=False keeps only the label property."""
     output_path = tmp_zarr + "/test_skeletonize_segprops_optout"
     Skeletonize(
         segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
@@ -1109,6 +1144,18 @@ def test_skeletonize_segment_properties_opt_out(tmp_zarr, tmp_skeletonize_csv):
 
     seg = _read_seg_props(output_path, "full")
     ids_in_props = {p["id"] for p in seg["inline"]["properties"]}
-    assert ids_in_props == {"label"}, (
-        f"expected only 'label' property when opted out, got {ids_in_props}"
-    )
+    assert ids_in_props == {"label"}
+
+
+def test_skeletonize_segment_properties_invalid_key_raises(tmp_zarr, tmp_skeletonize_csv):
+    """Unknown metric keys in the list raise with a clear message."""
+    with pytest.raises(ValueError, match="unknown skeleton_properties"):
+        Skeletonize(
+            segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+            output_path=tmp_zarr + "/test_skeletonize_segprops_bad",
+            csv_path=tmp_skeletonize_csv,
+            erosion=False,
+            num_workers=1,
+            sharded=False,
+            skeleton_properties=["num_branches", "not_a_real_metric"],
+        )


### PR DESCRIPTION
## Summary

Skeleton metrics (`num_branches`, `longest_shortest_path_nm`, `radius_mean_nm`, `radius_std_nm`) were already computed and saved to `<csv>_with_skeletons.csv`. This PR also writes them into the neuroglancer `segment_properties/info` as `number` properties, so they surface as sortable columns in the layer's side panel. Zero extra compute, big discoverability win (sort by longest path, click the top entry).

### What gets written
The existing `label` property is preserved. Four numeric properties are appended:

| id | type / data_type | description |
|---|---|---|
| `num_branches` | number / int32 | Number of skeleton branches |
| `longest_shortest_path_nm` | number / float32 | Longest shortest path through the skeleton (nm) |
| `radius_mean_nm` | number / float32 | Mean skeleton radius from EDT (nm) |
| `radius_std_nm` | number / float32 | Std of skeleton radius (nm) |

NaN values (empty / Lee's-wiped skeletons) are written as 0 so the JSON stays strict (`allow_nan=False`) and neuroglancer doesn't choke. Sharding-aware: the `segment_properties/info` is independent of whether per-ID files are repacked into shards.

### Behavior
- **Default: on.** `Skeletonize(...)` writes the rich segment_properties at the end of `skeletonize()`. The old "label-only" file is still written initially (so the layer is valid before metrics are ready), then overwritten with the rich version after metrics are computed.
- **Opt-out:** `Skeletonize(..., skeleton_properties=False)` preserves the previous label-only behavior.

### Tests added (2, all green; full suite 215 passing)
- Default-on: segment_properties has the four numeric properties with correct types and lengths; ID 5 (the cross fixture) has `num_branches >= 3`, positive longest path, positive mean radius.
- Opt-out: only the `label` property is written.