### PR TITLE
Make Skeletonize csv_path optional; auto-run Measure when missing

### DIFF
--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -151,7 +151,7 @@ class Skeletonize(ComputeConfigMixin):
         self,
         segmentation_path,
         output_path,
-        csv_path,
+        csv_path=None,
         erosion=True,
         min_branch_length_nm=100,
         tolerance_nm=50,
@@ -174,9 +174,15 @@ class Skeletonize(ComputeConfigMixin):
         Args:
             segmentation_path: Path to the segmentation zarr dataset
             output_path: Path to the output directory for skeletons
-            csv_path: Path to CSV containing bounding box info with columns:
-                     MIN X (nm), MIN Y (nm), MIN Z (nm), MAX X (nm), MAX Y (nm), MAX Z (nm)
-                     and index column for IDs
+            csv_path: Optional path to a CSV with per-object bounding boxes
+                     (the kind Measure produces: ``Object ID`` index plus
+                     ``MIN X (nm)`` ... ``MAX Z (nm)`` columns). If left as
+                     ``None`` (the default), Measure is run on the
+                     segmentation to generate one at
+                     ``<output_path>/bboxes/<leaf>.csv``. Pass an existing
+                     path to skip the auto-measure step. A path that does
+                     not exist raises ``FileNotFoundError`` rather than
+                     silently auto-generating to that exact location.
             erosion: Controls pre-skeletonization erosion.
                      True or "full": standard binary erosion with 6-connectivity cross SE.
                      6: targeted removal of edge/vertex-only bridges (keep face-connected).
@@ -217,8 +223,18 @@ class Skeletonize(ComputeConfigMixin):
                      when planning waves (rest is dask/OS/library overhead).
         """
         super().__init__(num_workers)
+        self.segmentation_path = segmentation_path
         self.segmentation_idi = ImageDataInterface(segmentation_path, timeout=timeout)
         self.output_path = str(output_path).rstrip("/")
+
+        if csv_path is None:
+            csv_path = self._generate_bbox_csv()
+        elif not os.path.exists(csv_path):
+            raise FileNotFoundError(
+                f"csv_path {csv_path!r} does not exist. Pass csv_path=None "
+                f"to auto-generate bboxes via Measure, or provide an "
+                f"existing CSV (the kind Measure produces)."
+            )
         self.csv_path = csv_path
         # Normalize erosion parameter
         if erosion is True:
@@ -263,6 +279,39 @@ class Skeletonize(ComputeConfigMixin):
 
         logger.info(f"Loaded {len(self.ids)} IDs from {csv_path}")
         logger.info(f"Output will be written to {output_path}")
+
+    def _generate_bbox_csv(self):
+        """Run Measure on the segmentation to produce a per-object bbox CSV.
+
+        Used when the caller does not supply ``csv_path``. The CSV lands at
+        ``<output_path>/bboxes/<leaf>.csv`` so the user can find/reuse it
+        later (point a subsequent run at it via ``csv_path``).
+        """
+        from cellmap_analyze.analyze.measure import Measure
+        from cellmap_analyze.util.io_util import get_leaf_name_from_path
+
+        bbox_dir = os.path.join(self.output_path, "bboxes")
+        os.makedirs(bbox_dir, exist_ok=True)
+        logger.info(
+            "No csv_path provided; running Measure on %s to generate "
+            "per-object bboxes (output -> %s).",
+            self.segmentation_path,
+            bbox_dir,
+        )
+        Measure(
+            input_path=self.segmentation_path,
+            output_path=bbox_dir,
+            num_workers=self.num_workers,
+        ).get_measurements()
+
+        leaf = get_leaf_name_from_path(self.segmentation_path) or "measurements"
+        csv_path = os.path.join(bbox_dir, f"{leaf}.csv")
+        if not os.path.exists(csv_path):
+            raise RuntimeError(
+                f"Measure did not produce expected CSV at {csv_path}"
+            )
+        logger.info("Auto-generated bbox CSV at %s", csv_path)
+        return csv_path
 
     @staticmethod
     def _empty_metrics():

--- a/tests/operations/test_skeletonize.py
+++ b/tests/operations/test_skeletonize.py
@@ -1159,3 +1159,53 @@ def test_skeletonize_segment_properties_invalid_key_raises(tmp_zarr, tmp_skeleto
             sharded=False,
             skeleton_properties=["num_branches", "not_a_real_metric"],
         )
+
+
+def test_skeletonize_auto_measure_when_csv_omitted(tmp_zarr):
+    """Without a csv_path, Skeletonize runs Measure on the segmentation to
+    generate per-object bboxes at <output>/bboxes/<leaf>.csv, then proceeds
+    normally."""
+    output_path = tmp_zarr + "/test_skeletonize_auto_measure"
+    Skeletonize(
+        segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+        output_path=output_path,
+        # no csv_path: should auto-run Measure
+        erosion=False,
+        min_branch_length_nm=0,
+        tolerance_nm=0,
+        num_workers=1,
+        sharded=False,
+    ).skeletonize()
+
+    # The CSV should have been written under <output>/bboxes/
+    auto_csv = f"{output_path}/bboxes/segmentation_for_skeleton.csv"
+    assert os.path.exists(auto_csv), (
+        f"expected auto-generated bbox CSV at {auto_csv}"
+    )
+    # Has the columns Skeletonize needs (Measure's standard output).
+    df = pd.read_csv(auto_csv, index_col=0)
+    for col in [
+        "MIN X (nm)", "MIN Y (nm)", "MIN Z (nm)",
+        "MAX X (nm)", "MAX Y (nm)", "MAX Z (nm)",
+    ]:
+        assert col in df.columns, f"auto bbox CSV missing column {col!r}"
+
+    # Skeletons were produced for all IDs in segmentation_for_skeleton
+    for id_val in [1, 2, 3, 4, 5, 6, 7, 8]:
+        assert os.path.exists(f"{output_path}/full/{id_val}"), (
+            f"missing full skeleton for ID {id_val}"
+        )
+
+
+def test_skeletonize_missing_csv_path_raises(tmp_zarr):
+    """A csv_path that doesn't exist should error -- do not silently
+    auto-generate to that exact path."""
+    with pytest.raises(FileNotFoundError, match="csv_path"):
+        Skeletonize(
+            segmentation_path=f"{tmp_zarr}/segmentation_for_skeleton/s0",
+            output_path=tmp_zarr + "/test_skeletonize_missing_csv",
+            csv_path="/this/path/does/not/exist.csv",
+            erosion=False,
+            num_workers=1,
+            sharded=False,
+        )


### PR DESCRIPTION
@stuarteberg
## Summary

Until now `Skeletonize` required a per-object bbox CSV as input — you had to run `Measure` first and feed it in. This PR makes `csv_path` optional: if you don't supply one, `Skeletonize` runs `Measure` on the segmentation automatically and uses the resulting CSV at `<output_path>/bboxes/<leaf>.csv`. Pass `csv_path` later to skip the auto-measure on subsequent runs.

### API
| `csv_path` | behavior |
|---|---|
| `None` (default) | Run `Measure` on the segmentation, write to `<output_path>/bboxes/<leaf>.csv`, use it. |
| existing CSV path | Use it directly (existing behavior). |
| nonexistent path | `FileNotFoundError` — do not silently generate to that exact path (typo-protection). |

### Why this shape
- **Reusable output**: the auto-generated CSV uses `Measure`'s standard schema (`Object ID` + `MIN/MAX X/Y/Z` columns), so downstream tools see something indistinguishable from a hand-curated CSV, and the next skeletonize run can be pointed at it via `csv_path`.
- **No silent path-creation**: a misspelled `csv_path` should not turn into "we'll just make a new one there" — that breaks the user's mental model of where their data is. Passing `None` is the explicit opt-in.

### Tests added (2, all green; full suite 220 passing)
- `csv_path` omitted → CSV materialized at `<output>/bboxes/<leaf>.csv` with the expected MIN/MAX columns; all skeletons written.
- Nonexistent `csv_path` → `FileNotFoundError` mentioning `csv_path`.
