### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cellmap-analyze"
-version = "0.3.0"
+version = "0.3.1"
 description = "Code to perform analysis on segmentations like those produced by CellMap"
 readme = "README.md"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary
Patch release with the post-v0.3.0 hardening + skeletonize ergonomics:
- **#73** Prefer OME multiscales over per-array attrs; **error** on disagreement (stale per-array attrs can no longer silently shadow corrected OME group metadata)
- **#74** Bake per-ID skeleton metrics into the neuroglancer `segment_properties/info` so they show up as sortable side-panel columns; default subset is `num_branches` + `longest_shortest_path_nm`, with `'all'` / explicit list / `False` options
- **#75** Make Skeletonize `csv_path` optional — auto-runs Measure to generate per-object bboxes at `<output>/bboxes/<leaf>.csv` when not supplied
