### PR TITLE
Per-instance UUID on tmp/merge dirs to avoid concurrent collisions

### DIFF
--- a/src/cellmap_analyze/analyze/assign_to_organelles.py
+++ b/src/cellmap_analyze/analyze/assign_to_organelles.py
@@ -17,6 +17,7 @@ import pandas as pd
 import numpy as np
 import os
 import shutil
+import uuid
 from scipy import spatial
 import fastremap
 import fastmorph
@@ -59,6 +60,10 @@ class AssignToOrganelles(ComputeConfigMixin):
         self.assignment_type = assignment_type
         self.output_path = str(output_path).rstrip("/")
         self.iteration_distance_nm = iteration_distance_nm
+        # Per-instance suffix isolates this run's tmp/merge dirs from any
+        # concurrent run sharing output_path -- otherwise two parallel jobs
+        # write to the same .tmp_assign/coms.npy and stomp on each other.
+        self._run_id = uuid.uuid4().hex[:8]
 
     @staticmethod
     def _group_coms_by_block(coms_nm, organelle_idi, com_row_indices=None):
@@ -294,7 +299,7 @@ class AssignToOrganelles(ComputeConfigMixin):
 
     def _save_coms_to_tmp(self, coms):
         """Save COM array to a temp file for workers to read."""
-        tmp_dir = os.path.join(self.output_path, ".tmp_assign")
+        tmp_dir = os.path.join(self.output_path, f".tmp_assign_{self._run_id}")
         os.makedirs(tmp_dir, exist_ok=True)
         coms_path = os.path.join(tmp_dir, "coms.npy")
         np.save(coms_path, coms)
@@ -314,7 +319,9 @@ class AssignToOrganelles(ComputeConfigMixin):
         if not block_indices:
             return
 
-        output_dir = os.path.join(self.output_path, ".tmp_assign_containing")
+        output_dir = os.path.join(
+            self.output_path, f".tmp_assign_containing_{self._run_id}"
+        )
         results = dask_util.compute_blockwise_partitions(
             len(block_indices),
             self.num_workers,
@@ -362,7 +369,9 @@ class AssignToOrganelles(ComputeConfigMixin):
         if not block_indices:
             return
 
-        output_dir = os.path.join(self.output_path, ".tmp_assign_nearest")
+        output_dir = os.path.join(
+            self.output_path, f".tmp_assign_nearest_{self._run_id}"
+        )
         # Each block handles its own padding expansion internally
         results = dask_util.compute_blockwise_partitions(
             len(block_indices),

--- a/src/cellmap_analyze/process/clean_connected_components.py
+++ b/src/cellmap_analyze/process/clean_connected_components.py
@@ -8,6 +8,7 @@ from cellmap_analyze.util.dask_util import (
 from cellmap_analyze.util.image_data_interface import ImageDataInterface
 from cellmap_analyze.util.io_util import get_output_path_from_input_path
 import logging
+import uuid
 import itertools
 from cellmap_analyze.util.mask_util import MasksFromConfig
 import fastremap
@@ -85,6 +86,9 @@ class CleanConnectedComponents(ComputeConfigMixin):
         self.connectivity = connectivity
         self.fill_holes = fill_holes
         self.delete_tmp = delete_tmp
+        # Per-instance suffix so concurrent runs sharing output_path don't
+        # collide on the fixed-name merge dir.
+        self._run_id = uuid.uuid4().hex[:8]
 
     @staticmethod
     def volume_filter_connected_ids(
@@ -143,7 +147,8 @@ class CleanConnectedComponents(ComputeConfigMixin):
             merge_info=(
                 ConnectedComponents._merge_tuples,
                 get_output_path_from_input_path(
-                    self.output_path, "_tmp_cleaned_connected_component_info_to_merge"
+                    self.output_path,
+                    f"_tmp_cleaned_connected_component_info_to_merge_{self._run_id}",
                 ),
             ),
         )

--- a/src/cellmap_analyze/process/connected_components.py
+++ b/src/cellmap_analyze/process/connected_components.py
@@ -17,6 +17,7 @@ import networkx as nx
 import itertools
 import fastremap
 import os
+import uuid
 from cellmap_analyze.util.mask_util import MasksFromConfig
 from cellmap_analyze.util.mixins import ComputeConfigMixin
 from cellmap_analyze.util.zarr_util import create_multiscale_dataset_idi
@@ -166,6 +167,9 @@ class ConnectedComponents(ComputeConfigMixin):
         self.invert = invert
         self.delete_tmp = delete_tmp
         self.fill_holes = fill_holes
+        # Per-instance suffix isolates tmp/merge dirs from any concurrent run
+        # sharing output_path (otherwise the fixed-name dir races).
+        self._run_id = uuid.uuid4().hex[:8]
 
     @staticmethod
     def calculate_block_connected_components(
@@ -455,7 +459,8 @@ class ConnectedComponents(ComputeConfigMixin):
             merge_info=(
                 ConnectedComponents._merge_tuples,
                 get_output_path_from_input_path(
-                    self.output_path, "_tmp_connected_component_info_to_merge"
+                    self.output_path,
+                    f"_tmp_connected_component_info_to_merge_{self._run_id}",
                 ) + "/",
             ),
         )

--- a/src/cellmap_analyze/process/fill_holes.py
+++ b/src/cellmap_analyze/process/fill_holes.py
@@ -8,6 +8,7 @@ from cellmap_analyze.util.dask_util import (
 from cellmap_analyze.util.image_data_interface import ImageDataInterface
 
 import logging
+import uuid
 import fastremap
 from cellmap_analyze.util.io_util import get_output_path_from_input_path
 from cellmap_analyze.util.mixins import ComputeConfigMixin
@@ -42,6 +43,9 @@ class FillHoles(ComputeConfigMixin):
             self.roi = self.input_idi.roi
         self.voxel_size = self.input_idi.voxel_size
         self.connectivity = connectivity
+        # Per-instance suffix so concurrent runs sharing output_path don't
+        # collide on the fixed-name merge dir.
+        self._run_id = uuid.uuid4().hex[:8]
 
         if output_path is None:
             output_path = get_output_path_from_input_path(input_path, "_filled")
@@ -132,7 +136,8 @@ class FillHoles(ComputeConfigMixin):
             merge_info=(
                 FillHoles._merge_hole_to_object_dicts,
                 get_output_path_from_input_path(
-                    self.output_path, "_tmp_hole_objects_to_dict_to_merge"
+                    self.output_path,
+                    f"_tmp_hole_objects_to_dict_to_merge_{self._run_id}",
                 ),
             ),
         )

--- a/src/cellmap_analyze/process/skeletonize.py
+++ b/src/cellmap_analyze/process/skeletonize.py
@@ -14,6 +14,7 @@ from skimage.morphology import skeletonize, binary_erosion
 from tqdm import tqdm
 import logging
 import os
+import uuid
 import json
 
 logging.basicConfig(
@@ -265,6 +266,9 @@ class Skeletonize(ComputeConfigMixin):
         self.skeleton_properties = self._normalize_skeleton_properties(
             skeleton_properties
         )
+        # Per-instance suffix so concurrent runs sharing output_path don't
+        # collide on the wave merge dirs.
+        self._run_id = uuid.uuid4().hex[:8]
 
         # Load CSV with bounding box info
         self.bbox_df = pd.read_csv(csv_path, index_col=0)
@@ -800,7 +804,9 @@ class Skeletonize(ComputeConfigMixin):
         )
         self._log_wave_plan(waves)
 
-        tmp_merge_root = f"{self.output_path}/_tmp_skeleton_metrics_to_merge"
+        tmp_merge_root = (
+            f"{self.output_path}/_tmp_skeleton_metrics_to_merge_{self._run_id}"
+        )
         all_metrics = []
 
         for wave_index, wave in enumerate(waves, start=1):

--- a/tests/test_unique_tmp_dirs.py
+++ b/tests/test_unique_tmp_dirs.py
@@ -1,0 +1,158 @@
+"""Two operations sharing an output_path must not collide on a fixed-name
+tmp/merge directory. Each construction gets a per-instance UUID suffix so
+concurrent jobs can't stomp on each other's intermediate files.
+
+This test asserts the suffix is wired in for every op that previously had a
+fixed-name merge dir; it does not exercise concurrency directly, but the
+distinct ``_run_id`` is the structural guarantee that makes concurrent
+output_path sharing safe.
+"""
+import os
+import re
+
+import numpy as np
+import pandas as pd
+import pytest
+import zarr
+from funlib.geometry import Coordinate, Roi
+
+from cellmap_analyze.process.skeletonize import Skeletonize
+from cellmap_analyze.process.connected_components import ConnectedComponents
+from cellmap_analyze.process.clean_connected_components import (
+    CleanConnectedComponents,
+)
+from cellmap_analyze.process.fill_holes import FillHoles
+from cellmap_analyze.analyze.assign_to_organelles import AssignToOrganelles
+from cellmap_analyze.util.zarr_util import create_multiscale_dataset
+
+
+HEX8 = re.compile(r"^[0-9a-f]{8}$")
+
+
+def _make_seg(path, shape=(8, 8, 8), vs=(8, 8, 8)):
+    """Helper: write a small labelled zarr."""
+    total_roi = Roi(Coordinate(0, 0, 0), Coordinate(shape) * Coordinate(vs))
+    ds = create_multiscale_dataset(
+        path,
+        dtype=np.uint8,
+        voxel_size=list(vs),
+        total_roi=total_roi,
+        write_size=Coordinate(shape) * Coordinate(vs),
+        original_voxel_size=list(vs),
+    )
+    arr = np.zeros(shape, dtype=np.uint8)
+    arr[2:5, 2:5, 2:5] = 1
+    ds.data[:] = arr
+    return f"{path}/s0"
+
+
+def _make_bbox_csv(path):
+    pd.DataFrame(
+        [
+            {
+                "Object ID": 1,
+                "MIN Z (nm)": 20.0,
+                "MIN Y (nm)": 20.0,
+                "MIN X (nm)": 20.0,
+                "MAX Z (nm)": 36.0,
+                "MAX Y (nm)": 36.0,
+                "MAX X (nm)": 36.0,
+            }
+        ]
+    ).set_index("Object ID").to_csv(path)
+
+
+def _make_coms_csv(path):
+    pd.DataFrame(
+        {
+            "Object ID": [1],
+            "COM X (nm)": [28.0],
+            "COM Y (nm)": [28.0],
+            "COM Z (nm)": [28.0],
+        }
+    ).to_csv(path, index=False)
+
+
+def test_skeletonize_run_id_unique(tmp_path):
+    seg = _make_seg(str(tmp_path / "seg.zarr/seg"))
+    csv = str(tmp_path / "bboxes.csv")
+    _make_bbox_csv(csv)
+    out = str(tmp_path / "skel_out")
+    a = Skeletonize(
+        segmentation_path=seg, output_path=out, csv_path=csv, sharded=False,
+        num_workers=1,
+    )
+    b = Skeletonize(
+        segmentation_path=seg, output_path=out, csv_path=csv, sharded=False,
+        num_workers=1,
+    )
+    assert a._run_id != b._run_id
+    assert HEX8.match(a._run_id) and HEX8.match(b._run_id)
+
+
+def test_connected_components_run_id_unique(tmp_path):
+    seg = _make_seg(str(tmp_path / "cc_in.zarr/seg"))
+    out = str(tmp_path / "cc_out.zarr/labels")
+    a = ConnectedComponents(
+        input_path=seg, output_path=out, intensity_threshold_minimum=1,
+        num_workers=1,
+    )
+    b = ConnectedComponents(
+        input_path=seg, output_path=out, intensity_threshold_minimum=1,
+        num_workers=1,
+    )
+    assert a._run_id != b._run_id
+
+
+def test_clean_connected_components_run_id_unique(tmp_path):
+    seg = _make_seg(str(tmp_path / "ccc_in.zarr/seg"))
+    out = str(tmp_path / "ccc_out.zarr/labels")
+    a = CleanConnectedComponents(input_path=seg, output_path=out, num_workers=1)
+    b = CleanConnectedComponents(input_path=seg, output_path=out, num_workers=1)
+    assert a._run_id != b._run_id
+
+
+def test_fill_holes_run_id_unique(tmp_path):
+    seg = _make_seg(str(tmp_path / "fh_in.zarr/seg"))
+    out = str(tmp_path / "fh_out.zarr/labels")
+    a = FillHoles(input_path=seg, output_path=out, num_workers=1)
+    b = FillHoles(input_path=seg, output_path=out, num_workers=1)
+    assert a._run_id != b._run_id
+
+
+def test_assign_to_organelles_run_id_unique(tmp_path):
+    target = _make_seg(str(tmp_path / "target.zarr/nuc"))
+    coms = str(tmp_path / "coms.csv")
+    _make_coms_csv(coms)
+    out = str(tmp_path / "assign_out")
+    a = AssignToOrganelles(
+        organelle_csvs=coms,
+        target_organelle_ds_path=target,
+        output_path=out,
+        num_workers=1,
+    )
+    b = AssignToOrganelles(
+        organelle_csvs=coms,
+        target_organelle_ds_path=target,
+        output_path=out,
+        num_workers=1,
+    )
+    assert a._run_id != b._run_id
+
+
+def test_run_ids_appear_in_tmp_paths_assign(tmp_path):
+    """The _run_id is actually used to scope ``.tmp_assign*`` paths."""
+    target = _make_seg(str(tmp_path / "target.zarr/nuc"))
+    coms = str(tmp_path / "coms.csv")
+    _make_coms_csv(coms)
+    out = str(tmp_path / "assign_out")
+    a = AssignToOrganelles(
+        organelle_csvs=coms,
+        target_organelle_ds_path=target,
+        output_path=out,
+        num_workers=1,
+    )
+    # _save_coms_to_tmp builds the directory path from self._run_id
+    coms_path = a._save_coms_to_tmp(np.array([[1.0, 1.0, 1.0]]))
+    assert a._run_id in coms_path
+    assert ".tmp_assign_" + a._run_id in coms_path


### PR DESCRIPTION
## Summary

Operations with fixed-name tmp/merge directories under `output_path` raced when two jobs shared an `output_path`. The example that prompted this: every `AssignToOrganelles` run was writing to `<output_path>/.tmp_assign/coms.npy`, so two parallel assigns clobbered each other's source COMs.

Same shape applied to the merge dirs in `connected_components` / `clean_connected_components` / `fill_holes` (chunk-indexed pickles colliding across runs) and to `skeletonize`'s wave merge dirs (`_tmp_skeleton_metrics_to_merge_wave{i}`). Failure mode is **mid-run `UnpicklingError` / `FileNotFoundError`**, or in the rare case both jobs make it through, a **silently wrong** merged result.

### Fix
Each operation generates a per-instance `self._run_id = uuid.uuid4().hex[:8]` on construction and embeds it in every fixed-name tmp path. Five files, one pattern:

| op | path before | path after |
|---|---|---|
| `AssignToOrganelles` | `.tmp_assign/coms.npy` | `.tmp_assign_<id>/coms.npy` |
| `AssignToOrganelles` | `.tmp_assign_containing/` | `.tmp_assign_containing_<id>/` |
| `AssignToOrganelles` | `.tmp_assign_nearest/` | `.tmp_assign_nearest_<id>/` |
| `ConnectedComponents` | `_tmp_connected_component_info_to_merge/` | `_tmp_connected_component_info_to_merge_<id>/` |
| `CleanConnectedComponents` | `_tmp_cleaned_connected_component_info_to_merge/` | `_tmp_cleaned_connected_component_info_to_merge_<id>/` |
| `FillHoles` | `_tmp_hole_objects_to_dict_to_merge/` | `_tmp_hole_objects_to_dict_to_merge_<id>/` |
| `Skeletonize` | `_tmp_skeleton_metrics_to_merge[_wave{i}]/` | `_tmp_skeleton_metrics_to_merge_<id>[_wave{i}]/` |

`Measure`'s tmp dir was already input-named (`measurements_to_merge_<leaf>/`) so it didn't have this problem and is unchanged.

### Behavior
- **Single run**: identical to before, just with the suffix in path names — no observable change.
- **Concurrent runs sharing `output_path`**: now write to disjoint directories. Each can crash, finish, or be cancelled without touching the other's intermediate files.

### Tests added (6, all green; full suite 226 passing)
- One per op asserting two same-`output_path` constructions get distinct 8-hex `_run_id`s.
- One asserting the `_run_id` actually appears in `_save_coms_to_tmp`'s returned path (i.e. the suffix is wired in, not just stored on the instance).
