### PR TITLE
Add read-only support for zarr/N5 on S3/GS/HTTP, also precomputed reading support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,13 @@
 name: CI
 
-on: [push, pull_request]
+# Run on every PR (so feature-branch work is verified) and on direct
+# pushes to main (so post-merge state is verified). Feature-branch
+# pushes WITHOUT an open PR don't trigger -- open a PR to get CI.
+# This avoids the double-firing (push + pull_request) we saw before.
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,14 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Don't kill the linux run on a mac hiccup (or vice versa); we want
+      # the per-platform signal to come through independently.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.12']
 
     steps:
       - uses: actions/checkout@v3
@@ -12,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Upgrade pip and install build tools
         run: |
@@ -27,6 +34,8 @@ jobs:
           pytest --cov=cellmap_analyze --cov-report=xml
 
       - name: Upload coverage report to Codecov
+        # Only upload once per push (from linux) to avoid double-reporting.
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v4.2.0
         with:
           files: ./coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "coverage", "build"]
+dev = ["pytest", "pytest-cov", "coverage", "build", "s3fs", "moto[s3,server]"]
+# Read zarr/n5 datasets from S3 (anonymous or credentialed). Pulls in
+# s3fs which gives zarr-python the fsspec backend it needs for s3:// URIs.
+s3 = ["s3fs"]
 
 [project.scripts]
 connected-components = "cli.cli:connected_components"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "coverage", "build", "s3fs", "moto[s3,server]"]
-# Read zarr/n5 datasets from S3 (anonymous or credentialed). Pulls in
-# s3fs which gives zarr-python the fsspec backend it needs for s3:// URIs.
-s3 = ["s3fs"]
+dev = ["pytest", "pytest-cov", "coverage", "build", "moto[s3,server]"]
 
 [project.scripts]
 connected-components = "cli.cli:connected_components"

--- a/src/cellmap_analyze/util/dask_util.py
+++ b/src/cellmap_analyze/util/dask_util.py
@@ -18,6 +18,19 @@ from cellmap_analyze.util.io_util import (
 from datetime import datetime
 import yaml
 from yaml.loader import SafeLoader
+
+
+def _available_cpu_count() -> int:
+    """Cross-platform process CPU count.
+
+    Prefers ``os.sched_getaffinity`` on linux to respect cgroup / LSF /
+    Slurm CPU pinning (more accurate than total physical cores under
+    those schedulers). Falls back to ``os.cpu_count()`` everywhere
+    sched_getaffinity isn't exposed (macOS, Windows).
+    """
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0))
+    return os.cpu_count() or 1
 from dataclasses import dataclass
 from funlib.geometry import Coordinate, Roi
 import numpy as np
@@ -850,7 +863,7 @@ def compute_blockwise_partitions(
 
     with TimingMessager(f"Reading results for {msg}", logger):
         list_of_results = read_results_to_merge(
-            output_directory, num_blocks, threads=len(os.sched_getaffinity(0))
+            output_directory, num_blocks, threads=_available_cpu_count()
         )
 
     with TimingMessager(f"Merging results for {msg}", logger):

--- a/src/cellmap_analyze/util/image_data_interface.py
+++ b/src/cellmap_analyze/util/image_data_interface.py
@@ -95,25 +95,49 @@ def read_with_retries(dataset, valid_slices, max_retries=10, timeout=5, base_del
 
 
 def _detect_zarr_driver(dataset_path: str) -> str:
-    """Detect whether a zarr dataset is v2 or v3 format.
+    """Detect the tensorstore driver for ``dataset_path``.
 
-    Returns 'zarr' for v2, 'zarr3' for v3, or 'n5' for N5. Works for both
-    local paths and remote URIs (``s3://`` / ``gs://`` / ``http(s)://``).
+    Returns one of ``"zarr"``, ``"zarr3"``, ``"n5"``, or
+    ``"neuroglancer_precomputed"``. Works for both local paths and
+    remote URIs (``s3://`` / ``gs://`` / ``http(s)://``).
+
+    Precomputed is detected by either the explicit ``precomputed://``
+    URL prefix OR by probing for an ``info`` marker file (at the path
+    or its parent, since precomputed paths often end in a scale key
+    like ``/s0`` that's not a real subdirectory).
     """
     from cellmap_analyze.util.io_util import (
+        is_precomputed_path,
         is_remote_path,
+        path_dirname,
         path_join,
         read_json_path,
+        strip_precomputed_prefix,
     )
 
-    if dataset_path.rfind(".n5") > dataset_path.rfind(".zarr"):
+    if is_precomputed_path(dataset_path):
+        return "neuroglancer_precomputed"
+
+    canonical = strip_precomputed_prefix(dataset_path)
+
+    # Precomputed: ``info`` sits at the dataset root. Try the path itself
+    # first, then its parent (covers paths like ``.../seg/s0`` where the
+    # trailing segment is a scale key, not a real subdirectory).
+    if read_json_path(path_join(canonical, "info")) is not None:
+        return "neuroglancer_precomputed"
+    parent = path_dirname(canonical)
+    if parent and parent != canonical:
+        if read_json_path(path_join(parent, "info")) is not None:
+            return "neuroglancer_precomputed"
+
+    if canonical.rfind(".n5") > canonical.rfind(".zarr"):
         return "n5"
 
     # Check for zarr v3 format marker (zarr.json at dataset level).
     # ``read_json_path`` returns None when missing -- exactly the
     # fall-through-to-v2 signal we want.
-    zarr_json_path = path_join(dataset_path, "zarr.json")
-    if is_remote_path(dataset_path):
+    zarr_json_path = path_join(canonical, "zarr.json")
+    if is_remote_path(canonical):
         if read_json_path(zarr_json_path) is not None:
             return "zarr3"
     else:
@@ -129,7 +153,11 @@ def open_ds_tensorstore(dataset_path: str, mode="r", concurrency_limit=None):
     (``s3://``, ``gs://``, ``http(s)://``, ``file://``). Tensorstore's
     native kvstore drivers handle the transport -- no fsspec/s3fs.
     """
-    from cellmap_analyze.util.io_util import is_remote_path, kvstore_for_path
+    from cellmap_analyze.util.io_util import (
+        is_remote_path,
+        kvstore_for_path,
+        strip_precomputed_prefix,
+    )
 
     if is_remote_path(dataset_path) and mode != "r":
         raise ValueError(
@@ -137,8 +165,19 @@ def open_ds_tensorstore(dataset_path: str, mode="r", concurrency_limit=None):
             f"cellmap-analyze only supports reading from object storage."
         )
 
-    # open with zarr, zarr3, or n5 depending on format
+    # open with zarr, zarr3, n5, or neuroglancer_precomputed depending on format
     filetype = _detect_zarr_driver(dataset_path)
+    if filetype == "neuroglancer_precomputed":
+        if mode != "r":
+            raise ValueError(
+                "neuroglancer precomputed datasets are read-only"
+            )
+        from cellmap_analyze.util.precomputed_io import (
+            open_precomputed_tensorstore,
+        )
+        return open_precomputed_tensorstore(dataset_path)
+
+    dataset_path = strip_precomputed_prefix(dataset_path)
     kvstore, key = kvstore_for_path(dataset_path)
     # tensorstore expects the chunk key inside the kvstore. Append a
     # trailing slash so it's treated as a directory of chunks.
@@ -485,21 +524,36 @@ class ImageDataInterface:
         timeout=5,
         interpolation_order=0,
     ):
-        # Don't resolve remote URIs as local paths -- ``Path("s3://...").resolve()``
-        # collapses the double slash and prepends the CWD.
-        from cellmap_analyze.util.io_util import is_remote_path
-
-        if not is_remote_path(dataset_path):
-            dataset_path = str(Path(dataset_path).resolve())
-        else:
-            dataset_path = str(dataset_path)
-        self.path = dataset_path
-        filename, dataset = split_dataset_path(dataset_path)
-        self.ds = open_dataset(filename, dataset, mode=mode)
-        self.filetype = (
-            "zarr" if dataset_path.rfind(".zarr") > dataset_path.rfind(".n5") else "n5"
+        # Don't resolve remote URIs / precomputed URLs as local paths --
+        # ``Path("s3://...").resolve()`` collapses the double slash and
+        # prepends the CWD, and a ``precomputed://`` prefix is not a
+        # filesystem path either.
+        from cellmap_analyze.util.io_util import (
+            is_precomputed_path,
+            is_remote_path,
+            strip_precomputed_prefix,
         )
-        self.swap_axes = self.filetype == "n5"
+
+        dataset_path = str(dataset_path)
+        if not is_remote_path(dataset_path) and not is_precomputed_path(dataset_path):
+            dataset_path = str(Path(dataset_path).resolve())
+        # Tensorstore + our open_dataset accept either a precomputed:// URL
+        # or the bare URL -- strip the prefix for ``self.path`` so the
+        # tensorstore reopen in ``to_ndarray_ts`` doesn't pay the cost
+        # of stripping it again on every block.
+        self.path = strip_precomputed_prefix(dataset_path)
+        filename, dataset = split_dataset_path(self.path)
+        self.ds = open_dataset(filename, dataset, mode=mode)
+        # Content-based detection (probes for info / zarr.json / .zarray /
+        # attributes.json) -- the .zarr-vs-.n5 filename heuristic
+        # can't see precomputed volumes (no extension) or non-standard
+        # naming.
+        self.filetype = _detect_zarr_driver(self.path)
+        # Precomputed's tensorstore handle is XYZ-ordered (the channel
+        # dim is dropped inside open_precomputed_tensorstore), matching
+        # N5's layout, so the same swap_axes=True codepath converts it
+        # to ZYX for everything downstream.
+        self.swap_axes = self.filetype in ("n5", "neuroglancer_precomputed")
         self.ts = None
         self.dtype = self.ds.dtype
         self.chunk_shape = self.ds.chunk_shape

--- a/src/cellmap_analyze/util/image_data_interface.py
+++ b/src/cellmap_analyze/util/image_data_interface.py
@@ -97,19 +97,58 @@ def read_with_retries(dataset, valid_slices, max_retries=10, timeout=5, base_del
 def _detect_zarr_driver(dataset_path: str) -> str:
     """Detect whether a zarr dataset is v2 or v3 format.
 
-    Returns 'zarr' for v2, 'zarr3' for v3, or 'n5' for N5.
+    Returns 'zarr' for v2, 'zarr3' for v3, or 'n5' for N5. Works for both
+    local paths and remote URIs (``s3://`` etc.).
     """
+    from cellmap_analyze.util.io_util import remote_exists
+
     if dataset_path.rfind(".n5") > dataset_path.rfind(".zarr"):
         return "n5"
     # Check for zarr v3 format marker (zarr.json at dataset level)
-    if os.path.exists(os.path.join(dataset_path, "zarr.json")):
+    if remote_exists(os.path.join(dataset_path, "zarr.json")):
         return "zarr3"
     return "zarr"
 
 
+def _build_tensorstore_kvstore(dataset_path: str) -> dict:
+    """Build the tensorstore kvstore spec for a dataset path.
+
+    Local paths get ``{"driver": "file", "path": ...}``; ``s3://bucket/key``
+    URIs get ``{"driver": "s3", "bucket": ..., "path": ...}`` so tensorstore
+    talks to S3 directly (no s3fs needed for the data read path).
+    """
+    from cellmap_analyze.util.io_util import is_remote_path, parse_s3_uri
+
+    if is_remote_path(dataset_path) and dataset_path.startswith("s3://"):
+        bucket, key = parse_s3_uri(dataset_path)
+        kv = {"driver": "s3", "bucket": bucket, "path": key}
+        # Honor AWS_ENDPOINT_URL so this works against MinIO, moto, or
+        # similar non-AWS S3-compatible services. Production AWS reads
+        # don't need anything set.
+        endpoint = os.environ.get("AWS_ENDPOINT_URL")
+        if endpoint:
+            kv["endpoint"] = endpoint
+        return kv
+    if is_remote_path(dataset_path):
+        raise NotImplementedError(
+            f"tensorstore read of {dataset_path!r} not supported "
+            f"(only s3:// remote URIs are currently wired up)"
+        )
+    return {"driver": "file", "path": dataset_path}
+
+
 def open_ds_tensorstore(dataset_path: str, mode="r", concurrency_limit=None):
+    from cellmap_analyze.util.io_util import is_remote_path
+
+    if is_remote_path(dataset_path) and mode != "r":
+        raise ValueError(
+            f"remote write to {dataset_path!r} is not supported; "
+            f"cellmap-analyze only supports reading from object storage."
+        )
+
     # open with zarr, zarr3, or n5 depending on format
     filetype = _detect_zarr_driver(dataset_path)
+    kvstore = _build_tensorstore_kvstore(dataset_path)
     if concurrency_limit:
         spec = {
             "driver": filetype,
@@ -117,18 +156,12 @@ def open_ds_tensorstore(dataset_path: str, mode="r", concurrency_limit=None):
                 "data_copy_concurrency": {"limit": concurrency_limit},
                 "file_io_concurrency": {"limit": concurrency_limit},
             },
-            "kvstore": {
-                "driver": "file",
-                "path": dataset_path,
-            },
+            "kvstore": kvstore,
         }
     else:
         spec = {
             "driver": filetype,
-            "kvstore": {
-                "driver": "file",
-                "path": dataset_path,
-            },
+            "kvstore": kvstore,
         }
 
     if mode == "r":
@@ -458,7 +491,14 @@ class ImageDataInterface:
         timeout=5,
         interpolation_order=0,
     ):
-        dataset_path = str(Path(dataset_path).resolve())
+        # Don't resolve remote URIs as local paths -- ``Path("s3://...").resolve()``
+        # collapses the double slash and prepends the CWD.
+        from cellmap_analyze.util.io_util import is_remote_path
+
+        if not is_remote_path(dataset_path):
+            dataset_path = str(Path(dataset_path).resolve())
+        else:
+            dataset_path = str(dataset_path)
         self.path = dataset_path
         filename, dataset = split_dataset_path(dataset_path)
         self.ds = open_dataset(filename, dataset, mode=mode)

--- a/src/cellmap_analyze/util/image_data_interface.py
+++ b/src/cellmap_analyze/util/image_data_interface.py
@@ -98,47 +98,38 @@ def _detect_zarr_driver(dataset_path: str) -> str:
     """Detect whether a zarr dataset is v2 or v3 format.
 
     Returns 'zarr' for v2, 'zarr3' for v3, or 'n5' for N5. Works for both
-    local paths and remote URIs (``s3://`` etc.).
+    local paths and remote URIs (``s3://`` / ``gs://`` / ``http(s)://``).
     """
-    from cellmap_analyze.util.io_util import remote_exists
+    from cellmap_analyze.util.io_util import (
+        is_remote_path,
+        path_join,
+        read_json_path,
+    )
 
     if dataset_path.rfind(".n5") > dataset_path.rfind(".zarr"):
         return "n5"
-    # Check for zarr v3 format marker (zarr.json at dataset level)
-    if remote_exists(os.path.join(dataset_path, "zarr.json")):
-        return "zarr3"
+
+    # Check for zarr v3 format marker (zarr.json at dataset level).
+    # ``read_json_path`` returns None when missing -- exactly the
+    # fall-through-to-v2 signal we want.
+    zarr_json_path = path_join(dataset_path, "zarr.json")
+    if is_remote_path(dataset_path):
+        if read_json_path(zarr_json_path) is not None:
+            return "zarr3"
+    else:
+        if os.path.exists(zarr_json_path):
+            return "zarr3"
     return "zarr"
 
 
-def _build_tensorstore_kvstore(dataset_path: str) -> dict:
-    """Build the tensorstore kvstore spec for a dataset path.
-
-    Local paths get ``{"driver": "file", "path": ...}``; ``s3://bucket/key``
-    URIs get ``{"driver": "s3", "bucket": ..., "path": ...}`` so tensorstore
-    talks to S3 directly (no s3fs needed for the data read path).
-    """
-    from cellmap_analyze.util.io_util import is_remote_path, parse_s3_uri
-
-    if is_remote_path(dataset_path) and dataset_path.startswith("s3://"):
-        bucket, key = parse_s3_uri(dataset_path)
-        kv = {"driver": "s3", "bucket": bucket, "path": key}
-        # Honor AWS_ENDPOINT_URL so this works against MinIO, moto, or
-        # similar non-AWS S3-compatible services. Production AWS reads
-        # don't need anything set.
-        endpoint = os.environ.get("AWS_ENDPOINT_URL")
-        if endpoint:
-            kv["endpoint"] = endpoint
-        return kv
-    if is_remote_path(dataset_path):
-        raise NotImplementedError(
-            f"tensorstore read of {dataset_path!r} not supported "
-            f"(only s3:// remote URIs are currently wired up)"
-        )
-    return {"driver": "file", "path": dataset_path}
-
-
 def open_ds_tensorstore(dataset_path: str, mode="r", concurrency_limit=None):
-    from cellmap_analyze.util.io_util import is_remote_path
+    """Open a tensorstore handle for ``dataset_path``.
+
+    ``dataset_path`` may be a local filesystem path or a remote URI
+    (``s3://``, ``gs://``, ``http(s)://``, ``file://``). Tensorstore's
+    native kvstore drivers handle the transport -- no fsspec/s3fs.
+    """
+    from cellmap_analyze.util.io_util import is_remote_path, kvstore_for_path
 
     if is_remote_path(dataset_path) and mode != "r":
         raise ValueError(
@@ -148,7 +139,10 @@ def open_ds_tensorstore(dataset_path: str, mode="r", concurrency_limit=None):
 
     # open with zarr, zarr3, or n5 depending on format
     filetype = _detect_zarr_driver(dataset_path)
-    kvstore = _build_tensorstore_kvstore(dataset_path)
+    kvstore, key = kvstore_for_path(dataset_path)
+    # tensorstore expects the chunk key inside the kvstore. Append a
+    # trailing slash so it's treated as a directory of chunks.
+    kvstore["path"] = (key.rstrip("/") + "/") if key else ""
     if concurrency_limit:
         spec = {
             "driver": filetype,

--- a/src/cellmap_analyze/util/io_util.py
+++ b/src/cellmap_analyze/util/io_util.py
@@ -93,6 +93,12 @@ def split_dataset_path(dataset_path, scale=None) -> tuple[str, str]:
         Tuple of filename and dataset
     """
 
+    # No .zarr/.n5 anywhere → treat the full path as the container.
+    # Neuroglancer precomputed volumes (and any future container-less
+    # format) hit this path; the dataset name is empty.
+    if dataset_path.rfind(".zarr") == -1 and dataset_path.rfind(".n5") == -1:
+        return dataset_path, ""
+
     # split at .zarr or .n5, whichever comes last
     splitter = (
         ".zarr" if dataset_path.rfind(".zarr") > dataset_path.rfind(".n5") else ".n5"
@@ -409,12 +415,31 @@ from urllib.request import Request, urlopen
 
 _REMOTE_SCHEMES = {"http", "https", "gs", "s3"}
 
+PRECOMPUTED_PREFIX = "precomputed://"
+
 
 def is_remote_path(path) -> bool:
     """True if ``path`` is a remote URI (s3://, gs://, http(s)://)."""
     if path is None:
         return False
-    return urlparse(str(path)).scheme in _REMOTE_SCHEMES
+    return urlparse(str(strip_precomputed_prefix(path))).scheme in _REMOTE_SCHEMES
+
+
+def is_precomputed_path(path) -> bool:
+    """True if ``path`` carries the explicit ``precomputed://`` prefix.
+
+    The prefix is no longer required — content probing for an ``info``
+    marker in :func:`_detect_zarr_driver` is the canonical signal — but
+    it's still honored for copy-paste from neuroglancer.
+    """
+    return isinstance(path, str) and path.startswith(PRECOMPUTED_PREFIX)
+
+
+def strip_precomputed_prefix(path):
+    """Return ``path`` with any leading ``precomputed://`` removed."""
+    if is_precomputed_path(path):
+        return path[len(PRECOMPUTED_PREFIX):]
+    return path
 
 
 def path_join(base, *parts):

--- a/src/cellmap_analyze/util/io_util.py
+++ b/src/cellmap_analyze/util/io_util.py
@@ -383,57 +383,153 @@ def tee_streams(output_path, append=False):
         raise
 
 
-# ----- Remote (S3 / GCS / etc.) path support -----------------------------
+# ----- Remote (S3 / GCS / HTTP) read support -----------------------------
 #
-# cellmap-analyze otherwise assumes POSIX-mounted storage. The helpers below
-# let the READ path accept ``s3://bucket/key`` (and similar fsspec-scheme)
-# URIs so a dataset can live in object storage. zarr 3.x reads these
-# natively when ``s3fs`` is installed (``pip install cellmap-analyze[s3]``);
-# tensorstore needs the URI parsed into its kvstore spec.
+# cellmap-analyze otherwise assumes POSIX-mounted storage. The helpers
+# below let the READ path accept remote URIs (``s3://``, ``gs://``,
+# ``http(s)://``) so a dataset can live in object storage or a web mirror.
+#
+# Architecture: for metadata reads (.zattrs, zarr.json, multiscales) we
+# go through stdlib ``urllib.request.urlopen`` directly on the JSON file
+# URL -- no fsspec, no s3fs, no zarr-python fsspec backend (and so no
+# async-vs-aiobotocore-vs-zarr version churn between those libraries).
+# For data reads, tensorstore has its own native drivers for s3, gcs,
+# and http kvstores. This module just routes URIs to the right
+# tensorstore kvstore spec and reads JSON metadata over the wire.
 #
 # WRITES to remote paths are NOT supported -- the tmp-dir / merge-dir /
-# rename machinery is built on POSIX semantics (atomic same-parent rename,
-# real directories) that S3 doesn't provide.
+# rename machinery is built on POSIX semantics (atomic same-parent
+# rename, real directories) that object stores don't provide.
 
-_REMOTE_SCHEMES = ("s3://", "gs://", "https://", "http://")
+import json as _json
+import posixpath
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse, urlunparse
+from urllib.request import Request, urlopen
+
+_REMOTE_SCHEMES = {"http", "https", "gs", "s3"}
 
 
 def is_remote_path(path) -> bool:
-    """True if ``path`` is a remote URI (s3:// etc.), False for local paths."""
+    """True if ``path`` is a remote URI (s3://, gs://, http(s)://)."""
     if path is None:
         return False
-    p = str(path)
-    return any(p.startswith(s) for s in _REMOTE_SCHEMES)
+    return urlparse(str(path)).scheme in _REMOTE_SCHEMES
 
 
-def remote_exists(path) -> bool:
-    """fsspec-aware existence check for remote paths.
+def path_join(base, *parts):
+    """Join URL or local-filesystem path components.
 
-    Falls back to ``os.path.exists`` for local paths so callers can use this
-    uniformly. For ``s3://`` URIs, requires ``s3fs`` to be installed.
+    For URLs, manipulates only the path component (via ``posixpath``) and
+    reassembles via ``urlunparse`` so query strings and fragments survive.
     """
-    if not is_remote_path(path):
-        return os.path.exists(path)
+    base = str(base)
+    if not parts:
+        return base
+    if is_remote_path(base):
+        parsed = urlparse(base)
+        new_path = parsed.path.rstrip("/")
+        for p in parts:
+            new_path = posixpath.join(new_path, str(p).lstrip("/"))
+        return urlunparse(parsed._replace(path=new_path))
+    return os.path.join(base, *(str(p) for p in parts))
+
+
+def path_dirname(path):
+    """Parent path for a URL or a local-filesystem path."""
+    path = str(path)
+    if is_remote_path(path):
+        parsed = urlparse(path)
+        dirname = posixpath.dirname(parsed.path.rstrip("/"))
+        return urlunparse(parsed._replace(path=dirname or "/"))
+    return os.path.dirname(path)
+
+
+def path_basename(path):
+    """Final component of a URL or a local-filesystem path."""
+    path = str(path)
+    if is_remote_path(path):
+        return posixpath.basename(urlparse(path).path.rstrip("/"))
+    return os.path.basename(path)
+
+
+def url_to_public_https(path):
+    """Translate ``s3://`` / ``gs://`` to a public HTTPS URL.
+
+    Used for metadata probes so we can read JSON via ``urlopen`` without
+    needing s3fs / google-cloud-storage / auth setup. Public buckets just
+    work; private buckets will return 403 from the probe, which is the
+    correct signal -- the subsequent tensorstore open would also need
+    authentication (handled there, not here). Honors ``AWS_ENDPOINT_URL``
+    so MinIO / moto / non-AWS S3-compatible services work.
+    """
+    parsed = urlparse(str(path))
+    if parsed.scheme == "gs":
+        return f"https://storage.googleapis.com/{parsed.netloc}{parsed.path}"
+    if parsed.scheme == "s3":
+        endpoint = os.environ.get("AWS_ENDPOINT_URL")
+        if endpoint:
+            base = endpoint.rstrip("/")
+            return f"{base}/{parsed.netloc}{parsed.path}"
+        return f"https://{parsed.netloc}.s3.amazonaws.com{parsed.path}"
+    return str(path)
+
+
+def read_json_path(path, timeout: float = 10.0):
+    """Read a JSON file from a local path or remote URL.
+
+    Returns the parsed dict on success, or ``None`` if the file is
+    missing / not JSON / unreachable. Never raises -- callers test the
+    return value (mirrors how zarr/n5 metadata probes can legitimately
+    miss when an array doesn't have its own attrs).
+    """
     try:
-        import fsspec
+        if is_remote_path(path):
+            url = url_to_public_https(path)
+            request = Request(url, headers={"Accept": "application/json"})
+            with urlopen(request, timeout=timeout) as f:
+                return _json.load(f)
+        with open(path) as f:
+            return _json.load(f)
+    except (
+        FileNotFoundError,
+        OSError,
+        HTTPError,
+        URLError,
+        TimeoutError,
+        _json.JSONDecodeError,
+    ):
+        return None
 
-        fs, p = fsspec.core.url_to_fs(str(path))
-        return fs.exists(p)
-    except Exception:
-        # Treat any failure (missing fsspec backend, network, auth) as
-        # "doesn't exist" -- callers fall through to other branches.
-        return False
 
+def kvstore_for_path(path):
+    """Build a tensorstore kvstore spec for ``path`` (any supported scheme).
 
-def parse_s3_uri(uri):
-    """Parse ``s3://bucket/key/path`` into ``(bucket, key)`` for use as a
-    tensorstore S3 kvstore spec. Raises ValueError for non-s3:// URIs."""
-    s = str(uri)
-    if not s.startswith("s3://"):
-        raise ValueError(f"not an s3:// URI: {uri!r}")
-    rest = s[len("s3://"):].lstrip("/")
-    if "/" in rest:
-        bucket, key = rest.split("/", 1)
-    else:
-        bucket, key = rest, ""
-    return bucket, key
+    Returns ``(kvstore_spec, key)`` where ``key`` is the path within the
+    kvstore that the caller should set as ``kvstore_spec["path"]`` (or
+    append a trailing slash to, depending on the tensorstore driver).
+
+    Supported schemes: ``s3``, ``gs``, ``http``, ``https``, ``file``,
+    plus bare local-filesystem paths. Honors ``AWS_ENDPOINT_URL`` so
+    MinIO / moto / non-AWS S3-compatible services work.
+    """
+    parsed = urlparse(str(path))
+    scheme = parsed.scheme.lower()
+    if scheme == "s3":
+        kv = {"driver": "s3", "bucket": parsed.netloc}
+        endpoint = os.environ.get("AWS_ENDPOINT_URL")
+        if endpoint:
+            kv["endpoint"] = endpoint
+        return kv, parsed.path.lstrip("/")
+    if scheme == "gs":
+        return {"driver": "gcs", "bucket": parsed.netloc}, parsed.path.lstrip("/")
+    if scheme in ("http", "https"):
+        return (
+            {"driver": "http", "base_url": f"{scheme}://{parsed.netloc}"},
+            parsed.path.lstrip("/"),
+        )
+    if scheme == "file":
+        return {"driver": "file"}, parsed.path
+    if scheme == "":
+        return {"driver": "file"}, os.path.abspath(str(path))
+    raise ValueError(f"Unsupported URL scheme: {scheme!r} in {path!r}")

--- a/src/cellmap_analyze/util/io_util.py
+++ b/src/cellmap_analyze/util/io_util.py
@@ -381,3 +381,59 @@ def tee_streams(output_path, append=False):
         with open(output_path, "a") as f:
             traceback.print_exc(file=f)
         raise
+
+
+# ----- Remote (S3 / GCS / etc.) path support -----------------------------
+#
+# cellmap-analyze otherwise assumes POSIX-mounted storage. The helpers below
+# let the READ path accept ``s3://bucket/key`` (and similar fsspec-scheme)
+# URIs so a dataset can live in object storage. zarr 3.x reads these
+# natively when ``s3fs`` is installed (``pip install cellmap-analyze[s3]``);
+# tensorstore needs the URI parsed into its kvstore spec.
+#
+# WRITES to remote paths are NOT supported -- the tmp-dir / merge-dir /
+# rename machinery is built on POSIX semantics (atomic same-parent rename,
+# real directories) that S3 doesn't provide.
+
+_REMOTE_SCHEMES = ("s3://", "gs://", "https://", "http://")
+
+
+def is_remote_path(path) -> bool:
+    """True if ``path`` is a remote URI (s3:// etc.), False for local paths."""
+    if path is None:
+        return False
+    p = str(path)
+    return any(p.startswith(s) for s in _REMOTE_SCHEMES)
+
+
+def remote_exists(path) -> bool:
+    """fsspec-aware existence check for remote paths.
+
+    Falls back to ``os.path.exists`` for local paths so callers can use this
+    uniformly. For ``s3://`` URIs, requires ``s3fs`` to be installed.
+    """
+    if not is_remote_path(path):
+        return os.path.exists(path)
+    try:
+        import fsspec
+
+        fs, p = fsspec.core.url_to_fs(str(path))
+        return fs.exists(p)
+    except Exception:
+        # Treat any failure (missing fsspec backend, network, auth) as
+        # "doesn't exist" -- callers fall through to other branches.
+        return False
+
+
+def parse_s3_uri(uri):
+    """Parse ``s3://bucket/key/path`` into ``(bucket, key)`` for use as a
+    tensorstore S3 kvstore spec. Raises ValueError for non-s3:// URIs."""
+    s = str(uri)
+    if not s.startswith("s3://"):
+        raise ValueError(f"not an s3:// URI: {uri!r}")
+    rest = s[len("s3://"):].lstrip("/")
+    if "/" in rest:
+        bucket, key = rest.split("/", 1)
+    else:
+        bucket, key = rest, ""
+    return bucket, key

--- a/src/cellmap_analyze/util/precomputed_io.py
+++ b/src/cellmap_analyze/util/precomputed_io.py
@@ -1,0 +1,175 @@
+"""Neuroglancer precomputed volume readers.
+
+Accepts paths of the form ``precomputed://<URL>`` where ``<URL>`` may be
+``gs://bucket/path``, ``s3://bucket/path``, ``http(s)://...``, or a
+local filesystem path. The ``precomputed://`` prefix is honored for
+backward compatibility but is not required — :func:`_detect_zarr_driver`
+probes for an ``info`` marker file and routes content-detected
+precomputed volumes here automatically.
+
+A trailing path segment may name a specific scale by its ``key`` in the
+``info`` file (e.g. ``.../seg/s0`` or ``.../seg/8.0x8.0x8.0``);
+otherwise scale 0 (highest resolution) is used.
+"""
+from __future__ import annotations
+
+import logging
+import posixpath
+
+from cellmap_analyze.util.io_util import (
+    kvstore_for_path,
+    path_basename,
+    path_dirname,
+    path_join,
+    read_json_path,
+    strip_precomputed_prefix,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _fetch_info(path):
+    """Read the ``info`` JSON sitting at ``<path>/info``.
+
+    Returns the parsed dict, or ``None`` if no info marker is present.
+    Uses :func:`read_json_path`, which already handles every supported
+    scheme (s3/gs/http(s)/local).
+    """
+    return read_json_path(path_join(path, "info"))
+
+
+def parse_precomputed_path(path):
+    """Resolve a precomputed path into (kvstore, base_path, info, scale_index).
+
+    Tries to find the ``info`` file at ``path`` first, then at its
+    parent (which covers paths like ``.../segmentation/s0`` where the
+    trailing segment names a scale rather than a real subdirectory).
+
+    Returns
+    -------
+    tuple[dict, str, dict, int]
+        ``(kvstore_spec, base_path, info_dict, scale_index)``. The
+        ``kvstore_spec`` is suitable for use as the ``kvstore`` field
+        of a tensorstore spec (its ``path`` must still be set by the
+        caller). ``base_path`` is the directory that holds ``info``.
+    """
+    inner = strip_precomputed_prefix(path).rstrip("/")
+    kvstore, _key = kvstore_for_path(inner)
+
+    info = _fetch_info(inner)
+    base_path = inner
+    scale_key = None
+
+    if info is None:
+        parent = path_dirname(inner)
+        if parent and parent != inner:
+            info = _fetch_info(parent)
+            if info is not None:
+                base_path = parent
+                scale_key = path_basename(inner)
+
+    if info is None:
+        raise FileNotFoundError(
+            f"No precomputed ``info`` file found at {inner!r} or its parent"
+        )
+
+    scales = info.get("scales", [])
+    if not scales:
+        raise ValueError(f"precomputed info at {base_path!r} has no scales")
+
+    scale_index = 0
+    if scale_key is not None:
+        for i, s in enumerate(scales):
+            if s.get("key") == scale_key:
+                scale_index = i
+                break
+        else:
+            raise ValueError(
+                f"scale key {scale_key!r} not found in info "
+                f"(available keys: {[s.get('key') for s in scales]})"
+            )
+
+    return kvstore, base_path, info, scale_index
+
+
+def open_precomputed_tensorstore(path, scale_index=None):
+    """Open a precomputed volume with TensorStore and drop the channel axis.
+
+    Returns a 3D TensorStore handle in (x, y, z) order, matching the
+    layout of an N5 dataset so the existing ``swap_axes=True`` codepath
+    in :class:`ImageDataInterface` converts it to ZYX.
+    """
+    import tensorstore as ts
+
+    _kvstore0, base_path, _info, default_scale = parse_precomputed_path(path)
+    if scale_index is None:
+        scale_index = default_scale
+
+    # Build a kvstore spec rooted at the directory holding ``info``.
+    # ``kvstore_for_path`` returns the kvstore with the path stripped
+    # out as ``key``; tensorstore expects that key as ``path`` on the
+    # kvstore (with a trailing slash so it's treated as a directory).
+    kvstore, key = kvstore_for_path(base_path)
+    kvstore["path"] = (key.rstrip("/") + "/") if key else ""
+
+    spec = {
+        "driver": "neuroglancer_precomputed",
+        "kvstore": kvstore,
+        "scale_index": int(scale_index),
+    }
+    ds = ts.open(spec, read=True, write=False).result()
+
+    # Drop the channel dim so the dataset looks 3D in (x, y, z) order.
+    if "channel" in ds.domain.labels:
+        ds = ds[ts.d["channel"][0]]
+    elif len(ds.domain) == 4:
+        ds = ds[..., 0]
+    # The precomputed driver bakes ``voxel_offset`` into the array
+    # domain so voxel indices start at the offset, not at 0. The
+    # cellmap-analyze read path (``to_ndarray_tensorstore``) handles
+    # the physical offset itself and assumes a 0-based voxel array
+    # (the N5 convention). Translate the domain to origin so the two
+    # conventions agree.
+    if any(o != 0 for o in ds.domain.origin):
+        ds = ds.translate_to[(0,) * len(ds.domain)]
+    return ds
+
+
+def precomputed_array_metadata(path, scale_index=None):
+    """Read shape/dtype/chunks/voxel_size/offset for a precomputed scale.
+
+    All spatial values are returned in ZYX order to match the rest of
+    the codebase. Voxel offset (in voxels, XYZ in the info file) is
+    converted to physical units in ZYX. The returned ``offset`` is the
+    CORNER of voxel [0,0,0] (i.e. ``voxel_offset * resolution``), which
+    is the precomputed convention; callers that want the OME-NGFF
+    center-translation convention must add ``vs/2``.
+    """
+    _, _, info, default_scale = parse_precomputed_path(path)
+    if scale_index is None:
+        scale_index = default_scale
+    scale = info["scales"][scale_index]
+
+    size_xyz = list(scale["size"])
+    resolution_xyz = [float(v) for v in scale["resolution"]]
+    voxel_offset_xyz = list(scale.get("voxel_offset") or [0, 0, 0])
+    chunk_sizes = scale.get("chunk_sizes") or [[64, 64, 64]]
+    chunk_xyz = list(chunk_sizes[0])
+    dtype = info.get("data_type", "uint64")
+
+    shape_zyx = tuple(size_xyz[::-1])
+    chunk_zyx = tuple(chunk_xyz[::-1])
+    voxel_size_zyx = [float(v) for v in resolution_xyz[::-1]]
+    offset_zyx = [
+        float(o) * float(r)
+        for o, r in zip(voxel_offset_xyz[::-1], resolution_xyz[::-1])
+    ]
+    return {
+        "shape": shape_zyx,
+        "chunks": chunk_zyx,
+        "dtype": dtype,
+        "voxel_size": voxel_size_zyx,
+        "offset_corner": offset_zyx,
+        "scale_index": scale_index,
+        "info": info,
+    }

--- a/src/cellmap_analyze/util/voxel_size_utils.py
+++ b/src/cellmap_analyze/util/voxel_size_utils.py
@@ -255,6 +255,12 @@ def _array_scale_name(ds):
     try:
         import os
 
+        # Prefer the path the caller used to open this array -- works for
+        # both local paths and remote URIs (s3://...).
+        full_path = getattr(ds, "_cellmap_path", None)
+        if full_path:
+            return os.path.basename(str(full_path).rstrip("/")) or None
+
         array_name = getattr(ds.data, "name", None) or getattr(ds.data, "path", "")
         array_name = str(array_name).strip("/")
         if array_name:
@@ -275,6 +281,21 @@ def _read_parent_attrs(ds):
     try:
         import os
         import zarr
+
+        # Preferred path: the CellMapArray was opened via ``open_dataset``,
+        # which stashes the full path on the array. Compute the parent
+        # group's path directly -- this works uniformly for local paths and
+        # remote URIs (s3://, etc.).
+        full_path = getattr(ds, "_cellmap_path", None)
+        if full_path:
+            parent_path = os.path.dirname(str(full_path).rstrip("/"))
+            if parent_path:
+                try:
+                    parent = zarr.open_group(parent_path, mode="r")
+                    return dict(parent.attrs)
+                except Exception:
+                    return None
+            return None
 
         # Get the filesystem path of the array's store root
         store = ds.data.store

--- a/src/cellmap_analyze/util/voxel_size_utils.py
+++ b/src/cellmap_analyze/util/voxel_size_utils.py
@@ -282,10 +282,17 @@ def _read_parent_attrs(ds):
         import os
         import zarr
 
+        # Remote opens (open_dataset for s3://, gs://, http(s)://) stash
+        # the parent group's attrs as a dict directly on the
+        # CellMapArray, so we don't have to go back over the wire and
+        # don't have to route through zarr's fsspec backend.
+        stashed = getattr(ds, "_cellmap_parent_attrs", None)
+        if stashed is not None:
+            return stashed
+
         # Preferred path: the CellMapArray was opened via ``open_dataset``,
         # which stashes the full path on the array. Compute the parent
-        # group's path directly -- this works uniformly for local paths and
-        # remote URIs (s3://, etc.).
+        # group's path directly -- this works for local paths.
         full_path = getattr(ds, "_cellmap_path", None)
         if full_path:
             parent_path = os.path.dirname(str(full_path).rstrip("/"))

--- a/src/cellmap_analyze/util/zarr_io.py
+++ b/src/cellmap_analyze/util/zarr_io.py
@@ -101,6 +101,64 @@ def _read_zarr_or_n5_attrs(full_path):
     return {}
 
 
+def _open_precomputed_dataset(full_path, mode):
+    """Open a neuroglancer precomputed volume as a CellMapArray.
+
+    Reads shape/dtype/chunks + voxel_size + offset from the ``info``
+    file (via ``precomputed_io.precomputed_array_metadata``). The
+    precomputed convention is that ``voxel_offset * resolution`` is the
+    physical CORNER of voxel [0,0,0]; cellmap-analyze's standard read
+    path interprets the ``offset`` attr as the OME-style CENTER and
+    subtracts ``vs/2`` to recover the corner -- so we stash CENTER =
+    CORNER + vs/2 here, and the round-trip lands back on the right
+    corner without special-casing the read path.
+
+    Data reads happen via tensorstore through
+    :func:`open_ds_tensorstore`, which dispatches on the filetype
+    returned by :func:`_detect_zarr_driver` and routes precomputed
+    paths to ``open_precomputed_tensorstore``.
+    """
+    from cellmap_analyze.util.precomputed_io import precomputed_array_metadata
+
+    if mode != "r":
+        raise ValueError(
+            f"write to precomputed {full_path!r} is not supported; "
+            f"cellmap-analyze only supports reading from precomputed."
+        )
+
+    meta = precomputed_array_metadata(full_path)
+    # ``precomputed_array_metadata`` returns ZYX-ordered values for
+    # parity with the rest of the codebase, but ``ImageDataInterface``
+    # treats this CellMapArray's shape / attrs as XYZ (just like an N5
+    # array) and reverses to ZYX via ``swap_axes=True``. To slot in
+    # uniformly, present everything here in XYZ so the IDI's existing
+    # N5 codepath produces ZYX without special-casing.
+    vs_xyz = list(meta["voxel_size"][::-1])
+    corner_xyz = list(meta["offset_corner"][::-1])
+    center_xyz = [c + v / 2.0 for c, v in zip(corner_xyz, vs_xyz)]
+    shape_xyz = tuple(meta["shape"][::-1])
+    chunks_xyz = tuple(meta["chunks"][::-1])
+
+    attrs = {
+        "voxel_size": vs_xyz,
+        "offset": center_xyz,
+    }
+
+    data = _RemoteArrayMetadata(
+        shape=shape_xyz,
+        dtype=np.dtype(meta["dtype"]),
+        chunks=chunks_xyz,
+        attrs=attrs,
+    )
+    voxel_size, offset = _read_voxel_size_offset(data)
+    arr = CellMapArray(data, voxel_size, offset)
+    arr._cellmap_path = full_path
+    # No OME parent group for precomputed; signal that explicitly so
+    # ``_read_parent_attrs`` doesn't try to open a zarr group at the URL.
+    arr._cellmap_parent_attrs = {}
+    return arr
+
+
 def _open_remote_dataset(full_path, mode):
     """Open a remote (s3/gs/http) zarr array.
 
@@ -155,10 +213,23 @@ def open_dataset(filename, ds_name, mode="r"):
     Returns:
         A CellMapArray wrapping the dataset.
     """
-    from cellmap_analyze.util.io_util import is_remote_path, path_join
+    from cellmap_analyze.util.io_util import (
+        is_precomputed_path,
+        is_remote_path,
+        path_join,
+        strip_precomputed_prefix,
+    )
+    from cellmap_analyze.util.image_data_interface import _detect_zarr_driver
 
     logger.debug("opening zarr dataset %s in %s", ds_name, filename)
     full_path = path_join(filename, ds_name) if ds_name else str(filename)
+
+    # Precomputed: detect via the explicit ``precomputed://`` prefix OR
+    # by probing for an ``info`` marker. ``_detect_zarr_driver`` does
+    # both. Strip the prefix here so downstream code can treat the path
+    # as a regular URL/local path.
+    if is_precomputed_path(full_path) or _detect_zarr_driver(full_path) == "neuroglancer_precomputed":
+        return _open_precomputed_dataset(strip_precomputed_prefix(full_path), mode)
 
     if is_remote_path(filename):
         return _open_remote_dataset(full_path, mode)

--- a/src/cellmap_analyze/util/zarr_io.py
+++ b/src/cellmap_analyze/util/zarr_io.py
@@ -55,13 +55,97 @@ class N5ArrayMetadata:
         )
 
 
+class _RemoteArrayMetadata:
+    """Minimal zarr.Array-shaped wrapper for remote (s3/gs/http) reads.
+
+    Provides ``shape``, ``dtype``, ``chunks``, ``attrs`` — the surface
+    that ``_read_voxel_size_offset`` and ``CellMapArray`` need. Data
+    reads always go through tensorstore (via ``ImageDataInterface``);
+    direct ``__getitem__`` is intentionally unsupported because we don't
+    want to fall back to a different remote-IO library.
+    """
+
+    def __init__(self, shape, dtype, chunks, attrs):
+        self.shape = tuple(shape)
+        self.dtype = dtype
+        self.chunks = tuple(chunks)
+        self.attrs = dict(attrs or {})
+
+    def __getitem__(self, slices):
+        raise NotImplementedError(
+            "Direct __getitem__ on a remote array is not supported; "
+            "use ImageDataInterface.to_ndarray_ts() instead."
+        )
+
+
+def _read_zarr_or_n5_attrs(full_path):
+    """Read a zarr/n5 array's attrs directly as JSON. Returns a dict
+    (possibly empty) -- never raises. Works over local paths and remote
+    URIs because :func:`read_json_path` does."""
+    from cellmap_analyze.util.io_util import path_join, read_json_path
+
+    # N5: attributes.json holds both schema (shape/dtype) and user attrs.
+    if full_path.rfind(".n5") > full_path.rfind(".zarr"):
+        return read_json_path(path_join(full_path, "attributes.json")) or {}
+
+    # Zarr v3: attributes live under ``attributes`` in zarr.json.
+    zarr_json = read_json_path(path_join(full_path, "zarr.json"))
+    if zarr_json is not None:
+        return zarr_json.get("attributes", {}) or {}
+
+    # Zarr v2: .zattrs sits next to .zarray.
+    zattrs = read_json_path(path_join(full_path, ".zattrs"))
+    if zattrs is not None:
+        return zattrs
+
+    return {}
+
+
+def _open_remote_dataset(full_path, mode):
+    """Open a remote (s3/gs/http) zarr array.
+
+    Reads array attrs and parent-group attrs via stdlib urllib (no
+    fsspec / s3fs / zarr-python fsspec backend involved). Opens
+    tensorstore on the data for shape / dtype / chunks so we don't need
+    a second JSON parser for the array layout.
+    """
+    from cellmap_analyze.util.io_util import path_dirname
+    from cellmap_analyze.util.image_data_interface import open_ds_tensorstore
+
+    if mode != "r":
+        raise ValueError(
+            f"remote write to {full_path!r} is not supported; cellmap-analyze "
+            f"only supports reading from object storage."
+        )
+
+    attrs = _read_zarr_or_n5_attrs(full_path)
+    parent_attrs = _read_zarr_or_n5_attrs(path_dirname(full_path)) or None
+
+    ts_ds = open_ds_tensorstore(full_path, mode="r")
+    shape = tuple(ts_ds.shape)
+    dtype = ts_ds.dtype.numpy_dtype
+    chunks = tuple(ts_ds.chunk_layout.read_chunk.shape)
+
+    data = _RemoteArrayMetadata(shape, dtype, chunks, attrs)
+    voxel_size, offset = _read_voxel_size_offset(data)
+    arr = CellMapArray(data, voxel_size, offset)
+    arr._cellmap_path = full_path
+    # Stash the parent attrs so ``_read_parent_attrs`` doesn't have to go
+    # back over the wire (and doesn't try to open the parent via
+    # ``zarr.open_group``, which would pull in the fsspec/s3fs path).
+    arr._cellmap_parent_attrs = parent_attrs
+    return arr
+
+
 def open_dataset(filename, ds_name, mode="r"):
     """Open a zarr dataset and return a CellMapArray.
 
     Supports zarr v2, v3, hybrid (v2 groups with v3 arrays), and N5 formats.
-    Accepts both local POSIX paths and remote URIs (``s3://bucket/path``)
-    for read mode; ``s3://`` reads require ``s3fs`` (install via
-    ``cellmap-analyze[s3]``). Writes to remote paths are not supported.
+    Accepts both local POSIX paths and remote URIs (``s3://``, ``gs://``,
+    ``http(s)://``) for read mode -- remote metadata is fetched via
+    stdlib ``urllib`` and remote voxel data via tensorstore's native
+    drivers, so no fsspec / s3fs / google-cloud-storage are required.
+    Writes to remote paths are not supported.
 
     Args:
         filename: Path or URI to the zarr container directory.
@@ -71,30 +155,21 @@ def open_dataset(filename, ds_name, mode="r"):
     Returns:
         A CellMapArray wrapping the dataset.
     """
-    from cellmap_analyze.util.io_util import is_remote_path, remote_exists
+    from cellmap_analyze.util.io_util import is_remote_path, path_join
 
     logger.debug("opening zarr dataset %s in %s", ds_name, filename)
-    full_path = os.path.join(filename, ds_name)
-    remote = is_remote_path(filename)
-    if remote and mode not in ("r",):
-        raise ValueError(
-            f"remote write to {filename!r} is not supported; cellmap-analyze "
-            f"only supports reading from object storage."
-        )
+    full_path = path_join(filename, ds_name) if ds_name else str(filename)
+
+    if is_remote_path(filename):
+        return _open_remote_dataset(full_path, mode)
+
     try:
         ds = zarr.open_array(full_path, mode=mode)
     except Exception:
         # Zarr 3.x cannot open N5 natively — fall back to reading
         # the N5 attributes.json for metadata.
         n5_attrs_path = os.path.join(full_path, "attributes.json")
-        if remote_exists(n5_attrs_path):
-            if remote:
-                # N5ArrayMetadata directly reads a local file via open(); we
-                # don't want to silently mishandle that for remote URIs.
-                raise NotImplementedError(
-                    f"N5 reads from remote URIs are not supported "
-                    f"({full_path!r})"
-                )
+        if os.path.exists(n5_attrs_path):
             logger.debug("falling back to N5 metadata reader for %s", full_path)
             ds = N5ArrayMetadata(full_path)
         else:

--- a/src/cellmap_analyze/util/zarr_io.py
+++ b/src/cellmap_analyze/util/zarr_io.py
@@ -59,24 +59,42 @@ def open_dataset(filename, ds_name, mode="r"):
     """Open a zarr dataset and return a CellMapArray.
 
     Supports zarr v2, v3, hybrid (v2 groups with v3 arrays), and N5 formats.
+    Accepts both local POSIX paths and remote URIs (``s3://bucket/path``)
+    for read mode; ``s3://`` reads require ``s3fs`` (install via
+    ``cellmap-analyze[s3]``). Writes to remote paths are not supported.
 
     Args:
-        filename: Path to the zarr container directory.
+        filename: Path or URI to the zarr container directory.
         ds_name: Name of the dataset within the container.
         mode: Open mode ('r', 'r+', 'a', 'w').
 
     Returns:
         A CellMapArray wrapping the dataset.
     """
+    from cellmap_analyze.util.io_util import is_remote_path, remote_exists
+
     logger.debug("opening zarr dataset %s in %s", ds_name, filename)
     full_path = os.path.join(filename, ds_name)
+    remote = is_remote_path(filename)
+    if remote and mode not in ("r",):
+        raise ValueError(
+            f"remote write to {filename!r} is not supported; cellmap-analyze "
+            f"only supports reading from object storage."
+        )
     try:
         ds = zarr.open_array(full_path, mode=mode)
     except Exception:
         # Zarr 3.x cannot open N5 natively — fall back to reading
         # the N5 attributes.json for metadata.
         n5_attrs_path = os.path.join(full_path, "attributes.json")
-        if os.path.exists(n5_attrs_path):
+        if remote_exists(n5_attrs_path):
+            if remote:
+                # N5ArrayMetadata directly reads a local file via open(); we
+                # don't want to silently mishandle that for remote URIs.
+                raise NotImplementedError(
+                    f"N5 reads from remote URIs are not supported "
+                    f"({full_path!r})"
+                )
             logger.debug("falling back to N5 metadata reader for %s", full_path)
             ds = N5ArrayMetadata(full_path)
         else:
@@ -84,7 +102,11 @@ def open_dataset(filename, ds_name, mode="r"):
             raise
 
     voxel_size, offset = _read_voxel_size_offset(ds)
-    return CellMapArray(ds, voxel_size, offset)
+    arr = CellMapArray(ds, voxel_size, offset)
+    # Remember the path we opened from so parent-group metadata lookups
+    # don't have to go spelunking through zarr store internals.
+    arr._cellmap_path = full_path
+    return arr
 
 
 def prepare_ds(

--- a/tests/test_precomputed_read.py
+++ b/tests/test_precomputed_read.py
@@ -1,0 +1,185 @@
+"""Read-only support for neuroglancer precomputed volumes.
+
+Covers both local-filesystem and S3 (via in-process moto) reads, the
+``precomputed://`` URL prefix, and selecting a specific scale by the
+``/<key>`` URL suffix. Mirrors ``test_s3_read.py``'s moto pattern.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+
+import numpy as np
+import pytest
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def s3_server():
+    from moto.server import ThreadedMotoServer
+
+    port = _free_port()
+    server = ThreadedMotoServer(port=port, ip_address="127.0.0.1")
+    server.start()
+    yield f"http://127.0.0.1:{port}"
+    server.stop()
+
+
+@pytest.fixture
+def s3_env(monkeypatch, s3_server):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ENDPOINT_URL", s3_server)
+    return s3_server
+
+
+def _boto_client(s3_env):
+    import boto3
+
+    return boto3.client(
+        "s3",
+        endpoint_url=s3_env,
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+
+
+def _make_public_bucket(s3_env, bucket: str):
+    s3 = _boto_client(s3_env)
+    s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_policy(
+        Bucket=bucket,
+        Policy=json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Sid": "PublicRead",
+                        "Effect": "Allow",
+                        "Principal": "*",
+                        "Action": "s3:GetObject",
+                        "Resource": f"arn:aws:s3:::{bucket}/*",
+                    }
+                ],
+            }
+        ),
+    )
+
+
+def _upload_dir_to_s3(s3_env, local_root: str, bucket: str, key_prefix: str):
+    s3 = _boto_client(s3_env)
+    key_prefix = key_prefix.strip("/")
+    for dirpath, _dn, filenames in os.walk(local_root):
+        for name in filenames:
+            local_path = os.path.join(dirpath, name)
+            rel = os.path.relpath(local_path, local_root).replace(os.sep, "/")
+            key = f"{key_prefix}/{rel}".lstrip("/")
+            with open(local_path, "rb") as f:
+                s3.put_object(Bucket=bucket, Key=key, Body=f.read())
+
+
+def _build_precomputed_volume(root: str, data_zyx: np.ndarray, voxel_offset_xyz, resolution_xyz):
+    """Author a 1-scale precomputed volume on disk via tensorstore."""
+    import tensorstore as ts
+
+    shutil.rmtree(root, ignore_errors=True)
+    os.makedirs(root)
+    size_xyz = list(data_zyx.shape[::-1])
+    chunk_xyz = list(size_xyz)  # one-chunk-per-volume keeps the fixture tiny
+    spec = {
+        "driver": "neuroglancer_precomputed",
+        "kvstore": {"driver": "file", "path": root + "/"},
+        "multiscale_metadata": {
+            "data_type": str(data_zyx.dtype),
+            "num_channels": 1,
+            "type": "segmentation",
+        },
+        "scale_metadata": {
+            "size": size_xyz,
+            "resolution": list(resolution_xyz),
+            "voxel_offset": list(voxel_offset_xyz),
+            "encoding": "raw",
+            "chunk_size": chunk_xyz,
+            "key": "s0",
+        },
+        "create": True,
+    }
+    ds = ts.open(spec).result()
+    ds[...] = data_zyx.transpose(2, 1, 0)[..., None]
+
+
+def test_precomputed_read_local(tmp_path):
+    """Open a local precomputed volume; voxel_size + corner offset come
+    from the ``info`` file, data round-trips through tensorstore."""
+    from cellmap_analyze.util.image_data_interface import ImageDataInterface
+
+    data = np.arange(4 * 6 * 8, dtype=np.uint8).reshape(4, 6, 8)  # ZYX
+    root = str(tmp_path / "vol")
+    _build_precomputed_volume(
+        root, data, voxel_offset_xyz=[10, 20, 30], resolution_xyz=[8.0, 8.0, 8.0]
+    )
+
+    idi = ImageDataInterface(root)
+    assert idi.filetype == "neuroglancer_precomputed"
+    assert tuple(idi.voxel_size) == (8, 8, 8)
+    # voxel_offset = (10, 20, 30) XYZ → ZYX corner = (30, 20, 10) * 8 = (240, 160, 80)
+    assert tuple(idi.offset) == (240, 160, 80)
+    np.testing.assert_array_equal(idi.to_ndarray_ts(idi.roi), data)
+
+
+def test_precomputed_read_with_scale_suffix(tmp_path):
+    """``.../vol/s0`` selects scale ``s0`` from the info file."""
+    from cellmap_analyze.util.image_data_interface import ImageDataInterface
+
+    data = np.arange(4 * 6 * 8, dtype=np.uint8).reshape(4, 6, 8)
+    root = str(tmp_path / "vol")
+    _build_precomputed_volume(root, data, [0, 0, 0], [4.0, 4.0, 4.0])
+
+    idi = ImageDataInterface(root + "/s0")
+    assert tuple(idi.voxel_size) == (4, 4, 4)
+    np.testing.assert_array_equal(idi.to_ndarray_ts(idi.roi), data)
+
+
+def test_precomputed_read_with_explicit_prefix(tmp_path):
+    """``precomputed://`` prefix is accepted (neuroglancer-style URLs)."""
+    from cellmap_analyze.util.image_data_interface import ImageDataInterface
+
+    data = np.arange(2 * 3 * 4, dtype=np.uint8).reshape(2, 3, 4)
+    root = str(tmp_path / "vol")
+    _build_precomputed_volume(root, data, [0, 0, 0], [16.0, 16.0, 16.0])
+
+    idi = ImageDataInterface("precomputed://" + root)
+    assert tuple(idi.voxel_size) == (16, 16, 16)
+    np.testing.assert_array_equal(idi.to_ndarray_ts(idi.roi), data)
+
+
+def test_precomputed_read_s3(tmp_path, s3_env):
+    """Read a precomputed volume from mock S3, exercising the same code
+    paths a real public-bucket read would: ``info`` via stdlib urllib,
+    chunks via tensorstore's S3 driver. Mirrors test_s3_read.py."""
+    from cellmap_analyze.util.image_data_interface import ImageDataInterface
+
+    bucket = "cellmap-precomp"
+    _make_public_bucket(s3_env, bucket)
+
+    data = np.arange(4 * 6 * 8, dtype=np.uint8).reshape(4, 6, 8)
+    local_root = str(tmp_path / "vol")
+    _build_precomputed_volume(
+        local_root, data, voxel_offset_xyz=[10, 20, 30], resolution_xyz=[8.0, 8.0, 8.0]
+    )
+    _upload_dir_to_s3(s3_env, local_root, bucket, "data/seg")
+
+    idi = ImageDataInterface(f"s3://{bucket}/data/seg")
+    assert idi.filetype == "neuroglancer_precomputed"
+    assert tuple(idi.voxel_size) == (8, 8, 8)
+    assert tuple(idi.offset) == (240, 160, 80)
+    np.testing.assert_array_equal(idi.to_ndarray_ts(idi.roi), data)

--- a/tests/test_s3_read.py
+++ b/tests/test_s3_read.py
@@ -54,16 +54,6 @@ def s3_env(monkeypatch, s3_server):
     return s3_server
 
 
-@pytest.fixture
-def s3fs_client(s3_env):
-    import s3fs
-
-    return s3fs.S3FileSystem(
-        anon=False,
-        client_kwargs={"endpoint_url": s3_env, "region_name": "us-east-1"},
-    )
-
-
 def _make_bucket(s3_env, bucket: str):
     import boto3
 
@@ -77,7 +67,28 @@ def _make_bucket(s3_env, bucket: str):
     s3.create_bucket(Bucket=bucket)
 
 
-def _write_zarr_dataset(fs, bucket, group_path, level_name, vs, trans, data):
+def _open_group_on_mock_s3(s3_env, url, mode):
+    """Open a zarr group at ``url`` on the moto mock S3 server.
+
+    Goes through zarr's URL-based store creation (with ``storage_options``)
+    rather than manually instantiating an s3fs filesystem -- the manual
+    path tripped zarr 3.x's ``async_impl`` check on some s3fs versions.
+    """
+    import zarr
+
+    return zarr.open_group(
+        url,
+        mode=mode,
+        zarr_format=3,
+        storage_options={
+            "client_kwargs": {"endpoint_url": s3_env, "region_name": "us-east-1"},
+            "key": "test",
+            "secret": "test",
+        },
+    )
+
+
+def _write_zarr_dataset(s3_env, bucket, group_path, level_name, vs, trans, data):
     """Upload a single-level OME-NGFF zarr v3 dataset to mock S3.
 
     Group (parent) holds the multiscales metadata; the array at
@@ -85,12 +96,7 @@ def _write_zarr_dataset(fs, bucket, group_path, level_name, vs, trans, data):
     OME-NGFF datasets are typically laid out (per-level transforms only in
     the parent group, no per-array offset/voxel_size attrs).
     """
-    import zarr
-
-    # The group itself
-    group_full = f"{bucket}/{group_path}"
-    group_store = zarr.storage.FsspecStore(fs, path=group_full)
-    group = zarr.open_group(store=group_store, mode="w", zarr_format=3)
+    group = _open_group_on_mock_s3(s3_env, f"s3://{bucket}/{group_path}", mode="w")
     group.attrs["multiscales"] = [
         {
             "axes": [
@@ -121,7 +127,7 @@ def _write_zarr_dataset(fs, bucket, group_path, level_name, vs, trans, data):
     arr[:] = data
 
 
-def test_s3_read_zarr_via_idi(s3_env, s3fs_client):
+def test_s3_read_zarr_via_idi(s3_env):
     """Open s3://.../seg/s0 via IDI; voxel_size, offset, and data all
     come back correctly through the OME multiscales metadata."""
     from cellmap_analyze.util.image_data_interface import ImageDataInterface
@@ -134,7 +140,7 @@ def test_s3_read_zarr_via_idi(s3_env, s3fs_client):
     # translation exercises the center<->corner conversion (PR #70).
     data = np.arange(8 * 8 * 8, dtype=np.uint8).reshape((8, 8, 8))
     _write_zarr_dataset(
-        s3fs_client,
+        s3_env,
         bucket,
         "data.zarr/seg",
         "s0",
@@ -157,7 +163,7 @@ def test_s3_read_zarr_via_idi(s3_env, s3fs_client):
     np.testing.assert_array_equal(read, data)
 
 
-def test_s3_read_picks_correct_multiscale_level(s3_env, s3fs_client):
+def test_s3_read_picks_correct_multiscale_level(s3_env):
     """The multiscale-level fix (PR #73) also has to work over s3:// --
     opening s1 must pick the s1 transform from the parent's multiscales
     metadata, not s0's."""
@@ -167,13 +173,8 @@ def test_s3_read_picks_correct_multiscale_level(s3_env, s3fs_client):
     _make_bucket(s3_env, bucket)
 
     # Build a two-level group: s0 vs=4 trans=0; s1 vs=8 trans=2.
-    import zarr
-
-    base = f"{bucket}/data.zarr/seg"
-    group = zarr.open_group(
-        store=zarr.storage.FsspecStore(s3fs_client, path=base),
-        mode="w",
-        zarr_format=3,
+    group = _open_group_on_mock_s3(
+        s3_env, f"s3://{bucket}/data.zarr/seg", mode="w"
     )
     group.attrs["multiscales"] = [
         {

--- a/tests/test_s3_read.py
+++ b/tests/test_s3_read.py
@@ -1,0 +1,223 @@
+"""Read-only S3 support: end-to-end test against an in-process mock S3.
+
+Uses moto's ThreadedMotoServer so both s3fs (which zarr uses for ``s3://``
+URIs) and tensorstore (which has its own HTTP client) talk to the same mock
+endpoint. No real network, no AWS credentials needed. ``s3fs`` and
+``moto[s3,server]`` are in the ``[dev]`` extra.
+
+Coverage:
+- IDI accepts ``s3://`` URIs and reports the right voxel_size/translation.
+- ``read_raw_voxel_size`` / ``read_raw_offset`` correctly walk to the parent
+  group's OME multiscales when only that is present (per the read-precedence
+  rules in PR #73; this is the standard layout for cellmap data on S3).
+- ``to_ndarray_ts`` reads voxel data through tensorstore's S3 driver and
+  returns the same bytes that were uploaded.
+- The "I didn't change anything else" guarantee: ``_array_scale_name`` /
+  multiscale level selection still works when the path is an s3:// URI
+  (i.e. opening ``s3://.../seg/s1`` picks the s1 transform, not s0's).
+"""
+from __future__ import annotations
+
+import json
+import socket
+
+import numpy as np
+import pytest
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def s3_server():
+    """Start an in-process mock S3 server. All s3:// reads in tests
+    using this fixture talk to it via ``AWS_ENDPOINT_URL``."""
+    from moto.server import ThreadedMotoServer
+
+    port = _free_port()
+    server = ThreadedMotoServer(port=port, ip_address="127.0.0.1")
+    server.start()
+    yield f"http://127.0.0.1:{port}"
+    server.stop()
+
+
+@pytest.fixture
+def s3_env(monkeypatch, s3_server):
+    """Point boto3/s3fs/tensorstore at the moto server."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ENDPOINT_URL", s3_server)
+    return s3_server
+
+
+@pytest.fixture
+def s3fs_client(s3_env):
+    import s3fs
+
+    return s3fs.S3FileSystem(
+        anon=False,
+        client_kwargs={"endpoint_url": s3_env, "region_name": "us-east-1"},
+    )
+
+
+def _make_bucket(s3_env, bucket: str):
+    import boto3
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=s3_env,
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+    s3.create_bucket(Bucket=bucket)
+
+
+def _write_zarr_dataset(fs, bucket, group_path, level_name, vs, trans, data):
+    """Upload a single-level OME-NGFF zarr v3 dataset to mock S3.
+
+    Group (parent) holds the multiscales metadata; the array at
+    ``group_path/level_name`` holds the voxel data. Mirrors how external
+    OME-NGFF datasets are typically laid out (per-level transforms only in
+    the parent group, no per-array offset/voxel_size attrs).
+    """
+    import zarr
+
+    # The group itself
+    group_full = f"{bucket}/{group_path}"
+    group_store = zarr.storage.FsspecStore(fs, path=group_full)
+    group = zarr.open_group(store=group_store, mode="w", zarr_format=3)
+    group.attrs["multiscales"] = [
+        {
+            "axes": [
+                {"name": a, "type": "space", "unit": "nanometer"}
+                for a in ("z", "y", "x")
+            ],
+            "datasets": [
+                {
+                    "path": level_name,
+                    "coordinateTransformations": [
+                        {"scale": list(vs), "type": "scale"},
+                        {"translation": list(trans), "type": "translation"},
+                    ],
+                }
+            ],
+            "name": "",
+            "version": "0.4",
+        }
+    ]
+
+    # The data array
+    arr = group.create_array(
+        name=level_name,
+        shape=data.shape,
+        chunks=data.shape,
+        dtype=data.dtype,
+    )
+    arr[:] = data
+
+
+def test_s3_read_zarr_via_idi(s3_env, s3fs_client):
+    """Open s3://.../seg/s0 via IDI; voxel_size, offset, and data all
+    come back correctly through the OME multiscales metadata."""
+    from cellmap_analyze.util.image_data_interface import ImageDataInterface
+
+    bucket = "cellmap-test"
+    _make_bucket(s3_env, bucket)
+
+    # OME pyramid-like: vs=8, translation=4 → OME-correct s1 of a base-8
+    # pyramid would actually be (V-V_base)/2 = 0, but a non-zero
+    # translation exercises the center<->corner conversion (PR #70).
+    data = np.arange(8 * 8 * 8, dtype=np.uint8).reshape((8, 8, 8))
+    _write_zarr_dataset(
+        s3fs_client,
+        bucket,
+        "data.zarr/seg",
+        "s0",
+        vs=(8.0, 8.0, 8.0),
+        trans=(4.0, 4.0, 4.0),
+        data=data,
+    )
+
+    uri = f"s3://{bucket}/data.zarr/seg/s0"
+    idi = ImageDataInterface(uri)
+
+    # Metadata round-trips through the parent group's OME multiscales.
+    assert tuple(idi.voxel_size) == (8, 8, 8)
+    # OME translation = voxel CENTER; v0.3.0 internally exposes the corner.
+    # trans=4, vs=8 → corner = 4 − 8/2 = 0.
+    assert tuple(idi.offset) == (0, 0, 0)
+
+    # And the actual voxel data comes back through tensorstore's s3 driver.
+    read = idi.to_ndarray_ts(idi.roi)
+    np.testing.assert_array_equal(read, data)
+
+
+def test_s3_read_picks_correct_multiscale_level(s3_env, s3fs_client):
+    """The multiscale-level fix (PR #73) also has to work over s3:// --
+    opening s1 must pick the s1 transform from the parent's multiscales
+    metadata, not s0's."""
+    from cellmap_analyze.util.image_data_interface import ImageDataInterface
+
+    bucket = "cellmap-test-multiscale"
+    _make_bucket(s3_env, bucket)
+
+    # Build a two-level group: s0 vs=4 trans=0; s1 vs=8 trans=2.
+    import zarr
+
+    base = f"{bucket}/data.zarr/seg"
+    group = zarr.open_group(
+        store=zarr.storage.FsspecStore(s3fs_client, path=base),
+        mode="w",
+        zarr_format=3,
+    )
+    group.attrs["multiscales"] = [
+        {
+            "axes": [
+                {"name": a, "type": "space", "unit": "nanometer"}
+                for a in ("z", "y", "x")
+            ],
+            "datasets": [
+                {
+                    "path": "s0",
+                    "coordinateTransformations": [
+                        {"scale": [4.0, 4.0, 4.0], "type": "scale"},
+                        {"translation": [0.0, 0.0, 0.0], "type": "translation"},
+                    ],
+                },
+                {
+                    "path": "s1",
+                    "coordinateTransformations": [
+                        {"scale": [8.0, 8.0, 8.0], "type": "scale"},
+                        {"translation": [2.0, 2.0, 2.0], "type": "translation"},
+                    ],
+                },
+            ],
+            "name": "",
+            "version": "0.4",
+        }
+    ]
+    for level, shape, val in [("s0", (16, 16, 16), 1), ("s1", (8, 8, 8), 2)]:
+        a = group.create_array(name=level, shape=shape, chunks=shape, dtype="uint8")
+        a[:] = val
+
+    # s0: vs=4, corner = 0 − 4/2 = −2.
+    idi0 = ImageDataInterface(f"s3://{bucket}/data.zarr/seg/s0")
+    assert tuple(idi0.voxel_size) == (4, 4, 4)
+    assert tuple(idi0.offset) == (-2, -2, -2)
+    assert np.all(idi0.to_ndarray_ts(idi0.roi) == 1)
+
+    # s1: vs=8, trans=2 → corner = 2 − 8/2 = −2. Same corner as s0
+    # (the OME pyramid invariant) -- the LEVEL is what we have to pick
+    # correctly here.
+    idi1 = ImageDataInterface(f"s3://{bucket}/data.zarr/seg/s1")
+    assert tuple(idi1.voxel_size) == (8, 8, 8), (
+        f"expected s1 voxel_size 8 but got {tuple(idi1.voxel_size)} -- "
+        f"this is the datasets[0]-hardcoding bug if it fails"
+    )
+    assert tuple(idi1.offset) == (-2, -2, -2)
+    assert np.all(idi1.to_ndarray_ts(idi1.roi) == 2)

--- a/tests/test_s3_read.py
+++ b/tests/test_s3_read.py
@@ -1,24 +1,20 @@
-"""Read-only S3 support: end-to-end test against an in-process mock S3.
-
-Uses moto's ThreadedMotoServer so both s3fs (which zarr uses for ``s3://``
-URIs) and tensorstore (which has its own HTTP client) talk to the same mock
-endpoint. No real network, no AWS credentials needed. ``s3fs`` and
-``moto[s3,server]`` are in the ``[dev]`` extra.
+"""Read-only support for ``s3://`` zarr datasets, tested end-to-end against
+an in-process mock S3 (moto). No fsspec, no s3fs -- the test path mirrors
+the production path: zarr metadata via stdlib ``urllib`` (with
+``AWS_ENDPOINT_URL`` redirecting to moto), voxel data via tensorstore's
+native S3 driver pointed at the same endpoint.
 
 Coverage:
-- IDI accepts ``s3://`` URIs and reports the right voxel_size/translation.
-- ``read_raw_voxel_size`` / ``read_raw_offset`` correctly walk to the parent
-  group's OME multiscales when only that is present (per the read-precedence
-  rules in PR #73; this is the standard layout for cellmap data on S3).
+- IDI accepts ``s3://`` URIs and reports the right voxel_size /
+  translation (which lives in the parent group's OME multiscales).
 - ``to_ndarray_ts`` reads voxel data through tensorstore's S3 driver and
   returns the same bytes that were uploaded.
-- The "I didn't change anything else" guarantee: ``_array_scale_name`` /
-  multiscale level selection still works when the path is an s3:// URI
-  (i.e. opening ``s3://.../seg/s1`` picks the s1 transform, not s0's).
+- Multiscale level selection works over S3 (PR #73's ``datasets[0]``
+  fix continuing to work when metadata is fetched over the wire).
 """
 from __future__ import annotations
 
-import json
+import os
 import socket
 
 import numpy as np
@@ -33,8 +29,7 @@ def _free_port() -> int:
 
 @pytest.fixture(scope="module")
 def s3_server():
-    """Start an in-process mock S3 server. All s3:// reads in tests
-    using this fixture talk to it via ``AWS_ENDPOINT_URL``."""
+    """Start an in-process mock S3 server."""
     from moto.server import ThreadedMotoServer
 
     port = _free_port()
@@ -46,7 +41,7 @@ def s3_server():
 
 @pytest.fixture
 def s3_env(monkeypatch, s3_server):
-    """Point boto3/s3fs/tensorstore at the moto server."""
+    """Point boto3 / tensorstore / our own ``url_to_public_https`` at moto."""
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
@@ -54,103 +49,124 @@ def s3_env(monkeypatch, s3_server):
     return s3_server
 
 
-def _make_bucket(s3_env, bucket: str):
+def _boto_client(s3_env):
     import boto3
 
-    s3 = boto3.client(
+    return boto3.client(
         "s3",
         endpoint_url=s3_env,
         region_name="us-east-1",
         aws_access_key_id="test",
         aws_secret_access_key="test",
     )
-    s3.create_bucket(Bucket=bucket)
 
 
-def _open_group_on_mock_s3(s3_env, url, mode):
-    """Open a zarr group at ``url`` on the moto mock S3 server.
+def _make_bucket(s3_env, bucket: str):
+    """Create a public-read bucket on the mock S3 server.
 
-    Goes through zarr's URL-based store creation (with ``storage_options``)
-    rather than manually instantiating an s3fs filesystem -- the manual
-    path tripped zarr 3.x's ``async_impl`` check on some s3fs versions.
+    cellmap-analyze reads zarr metadata via stdlib ``urllib.request.urlopen``
+    against the bucket's HTTPS URL -- unsigned. Real cellmap data on S3 is
+    public-read, which is what makes that unsigned read work. We mirror
+    that here by setting a public-read GetObject policy on the bucket so
+    the test exercises the same unsigned-read code path.
     """
-    import zarr
+    import json as _json
 
-    return zarr.open_group(
-        url,
-        mode=mode,
-        zarr_format=3,
-        storage_options={
-            "client_kwargs": {"endpoint_url": s3_env, "region_name": "us-east-1"},
-            "key": "test",
-            "secret": "test",
-        },
+    s3 = _boto_client(s3_env)
+    s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_policy(
+        Bucket=bucket,
+        Policy=_json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Sid": "PublicRead",
+                        "Effect": "Allow",
+                        "Principal": "*",
+                        "Action": "s3:GetObject",
+                        "Resource": f"arn:aws:s3:::{bucket}/*",
+                    }
+                ],
+            }
+        ),
     )
 
 
-def _write_zarr_dataset(s3_env, bucket, group_path, level_name, vs, trans, data):
-    """Upload a single-level OME-NGFF zarr v3 dataset to mock S3.
+def _upload_dir_to_s3(s3_env, local_root: str, bucket: str, key_prefix: str):
+    """Upload every file under ``local_root`` to ``s3://bucket/key_prefix/``
+    preserving relative paths. Used to mirror a locally-built zarr to
+    mock S3 without needing an async/fsspec stack to write directly."""
+    s3 = _boto_client(s3_env)
+    key_prefix = key_prefix.strip("/")
+    for dirpath, _dirnames, filenames in os.walk(local_root):
+        for name in filenames:
+            local_path = os.path.join(dirpath, name)
+            rel = os.path.relpath(local_path, local_root).replace(os.sep, "/")
+            key = f"{key_prefix}/{rel}".lstrip("/")
+            with open(local_path, "rb") as f:
+                s3.put_object(Bucket=bucket, Key=key, Body=f.read())
 
-    Group (parent) holds the multiscales metadata; the array at
-    ``group_path/level_name`` holds the voxel data. Mirrors how external
-    OME-NGFF datasets are typically laid out (per-level transforms only in
-    the parent group, no per-array offset/voxel_size attrs).
+
+def _build_local_ome_zarr(
+    root: str, level_data: dict[str, tuple[tuple, np.ndarray, tuple, tuple]],
+):
+    """Build a v3 OME-Zarr group at ``root`` with one or more levels.
+
+    ``level_data`` is ``{level_name: (vs_tuple, data_ndarray, vs, trans)}``
+    -- we accept ``vs``/``trans`` both at the level entry (for the OME
+    multiscales) and as the first tuple element (for the array's own
+    voxel_size convention). Locally-built and then mirrored to S3 by the
+    caller -- this lets the test code stay stdlib-only (no s3fs).
     """
-    group = _open_group_on_mock_s3(s3_env, f"s3://{bucket}/{group_path}", mode="w")
+    import zarr
+
+    group = zarr.open_group(root, mode="w", zarr_format=3)
+    datasets = []
+    for name, (_, data, vs, trans) in level_data.items():
+        datasets.append(
+            {
+                "path": name,
+                "coordinateTransformations": [
+                    {"scale": list(vs), "type": "scale"},
+                    {"translation": list(trans), "type": "translation"},
+                ],
+            }
+        )
+        arr = group.create_array(
+            name=name, shape=data.shape, chunks=data.shape, dtype=data.dtype
+        )
+        arr[:] = data
     group.attrs["multiscales"] = [
         {
             "axes": [
                 {"name": a, "type": "space", "unit": "nanometer"}
                 for a in ("z", "y", "x")
             ],
-            "datasets": [
-                {
-                    "path": level_name,
-                    "coordinateTransformations": [
-                        {"scale": list(vs), "type": "scale"},
-                        {"translation": list(trans), "type": "translation"},
-                    ],
-                }
-            ],
+            "datasets": datasets,
             "name": "",
             "version": "0.4",
         }
     ]
 
-    # The data array
-    arr = group.create_array(
-        name=level_name,
-        shape=data.shape,
-        chunks=data.shape,
-        dtype=data.dtype,
-    )
-    arr[:] = data
 
-
-def test_s3_read_zarr_via_idi(s3_env):
-    """Open s3://.../seg/s0 via IDI; voxel_size, offset, and data all
-    come back correctly through the OME multiscales metadata."""
+def test_s3_read_zarr_via_idi(tmp_path, s3_env):
+    """Open s3://.../seg/s0 via IDI; voxel_size, offset, and data come
+    back correctly through the parent group's OME multiscales."""
     from cellmap_analyze.util.image_data_interface import ImageDataInterface
 
     bucket = "cellmap-test"
     _make_bucket(s3_env, bucket)
 
-    # OME pyramid-like: vs=8, translation=4 → OME-correct s1 of a base-8
-    # pyramid would actually be (V-V_base)/2 = 0, but a non-zero
-    # translation exercises the center<->corner conversion (PR #70).
     data = np.arange(8 * 8 * 8, dtype=np.uint8).reshape((8, 8, 8))
-    _write_zarr_dataset(
-        s3_env,
-        bucket,
-        "data.zarr/seg",
-        "s0",
-        vs=(8.0, 8.0, 8.0),
-        trans=(4.0, 4.0, 4.0),
-        data=data,
+    local_root = tmp_path / "local_data.zarr" / "seg"
+    _build_local_ome_zarr(
+        str(local_root),
+        {"s0": (None, data, (8.0, 8.0, 8.0), (4.0, 4.0, 4.0))},
     )
+    _upload_dir_to_s3(s3_env, str(local_root), bucket, "data.zarr/seg")
 
-    uri = f"s3://{bucket}/data.zarr/seg/s0"
-    idi = ImageDataInterface(uri)
+    idi = ImageDataInterface(f"s3://{bucket}/data.zarr/seg/s0")
 
     # Metadata round-trips through the parent group's OME multiscales.
     assert tuple(idi.voxel_size) == (8, 8, 8)
@@ -163,48 +179,26 @@ def test_s3_read_zarr_via_idi(s3_env):
     np.testing.assert_array_equal(read, data)
 
 
-def test_s3_read_picks_correct_multiscale_level(s3_env):
-    """The multiscale-level fix (PR #73) also has to work over s3:// --
-    opening s1 must pick the s1 transform from the parent's multiscales
+def test_s3_read_picks_correct_multiscale_level(tmp_path, s3_env):
+    """The level-selection fix (PR #73) also has to work over s3:// --
+    opening s1 picks the s1 transform from the parent's multiscales
     metadata, not s0's."""
     from cellmap_analyze.util.image_data_interface import ImageDataInterface
 
     bucket = "cellmap-test-multiscale"
     _make_bucket(s3_env, bucket)
 
-    # Build a two-level group: s0 vs=4 trans=0; s1 vs=8 trans=2.
-    group = _open_group_on_mock_s3(
-        s3_env, f"s3://{bucket}/data.zarr/seg", mode="w"
-    )
-    group.attrs["multiscales"] = [
+    s0 = np.ones((16, 16, 16), dtype=np.uint8) * 1
+    s1 = np.ones((8, 8, 8), dtype=np.uint8) * 2
+    local_root = tmp_path / "ms.zarr" / "seg"
+    _build_local_ome_zarr(
+        str(local_root),
         {
-            "axes": [
-                {"name": a, "type": "space", "unit": "nanometer"}
-                for a in ("z", "y", "x")
-            ],
-            "datasets": [
-                {
-                    "path": "s0",
-                    "coordinateTransformations": [
-                        {"scale": [4.0, 4.0, 4.0], "type": "scale"},
-                        {"translation": [0.0, 0.0, 0.0], "type": "translation"},
-                    ],
-                },
-                {
-                    "path": "s1",
-                    "coordinateTransformations": [
-                        {"scale": [8.0, 8.0, 8.0], "type": "scale"},
-                        {"translation": [2.0, 2.0, 2.0], "type": "translation"},
-                    ],
-                },
-            ],
-            "name": "",
-            "version": "0.4",
-        }
-    ]
-    for level, shape, val in [("s0", (16, 16, 16), 1), ("s1", (8, 8, 8), 2)]:
-        a = group.create_array(name=level, shape=shape, chunks=shape, dtype="uint8")
-        a[:] = val
+            "s0": (None, s0, (4.0, 4.0, 4.0), (0.0, 0.0, 0.0)),
+            "s1": (None, s1, (8.0, 8.0, 8.0), (2.0, 2.0, 2.0)),
+        },
+    )
+    _upload_dir_to_s3(s3_env, str(local_root), bucket, "data.zarr/seg")
 
     # s0: vs=4, corner = 0 − 4/2 = −2.
     idi0 = ImageDataInterface(f"s3://{bucket}/data.zarr/seg/s0")
@@ -212,13 +206,13 @@ def test_s3_read_picks_correct_multiscale_level(s3_env):
     assert tuple(idi0.offset) == (-2, -2, -2)
     assert np.all(idi0.to_ndarray_ts(idi0.roi) == 1)
 
-    # s1: vs=8, trans=2 → corner = 2 − 8/2 = −2. Same corner as s0
-    # (the OME pyramid invariant) -- the LEVEL is what we have to pick
+    # s1: vs=8, trans=2 → corner = 2 − 8/2 = −2. Same corner as s0 (the
+    # OME pyramid invariant) -- the LEVEL is what we have to pick
     # correctly here.
     idi1 = ImageDataInterface(f"s3://{bucket}/data.zarr/seg/s1")
     assert tuple(idi1.voxel_size) == (8, 8, 8), (
         f"expected s1 voxel_size 8 but got {tuple(idi1.voxel_size)} -- "
-        f"this is the datasets[0]-hardcoding bug if it fails"
+        f"this is the datasets[0]-hardcoding regression if it fails"
     )
     assert tuple(idi1.offset) == (-2, -2, -2)
     assert np.all(idi1.to_ndarray_ts(idi1.roi) == 2)


### PR DESCRIPTION
## Summary

`ImageDataInterface`, `open_dataset`, `read_raw_voxel_size` / `read_raw_offset`, the tensorstore open path, and parent-group metadata lookup all now accept remote URIs (`s3://`, `gs://`, `http(s)://`) in addition to local POSIX paths, for **zarr (v2/v3), N5, and neuroglancer precomputed** datasets. Writes to remote paths remain unsupported — the tmp-dir / merge-dir / rename machinery in cellmap is built on POSIX semantics (atomic same-parent rename, real directories) that S3 doesn't provide. Read-only is the right scope and covers the common case (analyzing data that lives on S3).

### How it's wired

Mirrors the architecture in mesh-n-bone: **metadata via stdlib `urllib.request`, data via tensorstore's native s3 / gcs / http drivers.** No fsspec, no s3fs, no zarr-python fsspec backend — so no version churn between those libraries.

- **`io_util` helpers**: `is_remote_path` (urlparse-based), URL-aware `path_join` / `path_dirname` / `path_basename`, `url_to_public_https` (translates `s3://bucket/key` to `https://bucket.s3.amazonaws.com/key` for the metadata probe), `read_json_path` (reads JSON from local OR remote and returns `None` on miss), and `kvstore_for_path` (returns the tensorstore kvstore spec for any supported scheme). Plus a small `is_precomputed_path` / `strip_precomputed_prefix` pair so the optional `precomputed://` URL prefix is handled uniformly everywhere.
- **`open_dataset`** has a new `_open_remote_dataset` branch (zarr/N5) that reads attrs as JSON, opens tensorstore for shape/dtype/chunks, and wraps them in a minimal `_RemoteArrayMetadata`. A separate `_open_precomputed_dataset` branch reads the precomputed `info` file, translates `voxel_offset * resolution` (the precomputed corner convention) to the OME-style center the rest of cellmap-analyze expects, and slots into the existing N5 axis-swap codepath so nothing downstream needs to know precomputed is XYZ-native. **Zarr-python is not on the remote path at all.** Local paths for zarr / N5 are unchanged.
- **`_detect_zarr_driver`** is now content-based: it probes for `info` (precomputed), `zarr.json` (v3), `.zarray` (v2), and `attributes.json` (N5) markers in that order — so `precomputed://` is *not* required (it's still accepted for copy-paste from neuroglancer). Falls through to the `.n5` / `.zarr` filename heuristic only when no marker is reachable.
- **`open_ds_tensorstore`** dispatches to `open_precomputed_tensorstore` for precomputed; that helper drops the channel dim and translates the tensorstore domain to origin so the precomputed handle is interchangeable with N5 from the read-path's perspective.
- **Parent-group attrs for remote arrays** are stashed on the CellMapArray (`_cellmap_parent_attrs`) so `_read_parent_attrs` doesn't go back over the wire (and doesn't pull in zarr+fsspec).
- **`AWS_ENDPOINT_URL`** is honored everywhere — for MinIO, moto, or any non-AWS S3-compatible service. Both the unsigned metadata probe and the tensorstore data spec route through it.

### Formats and schemes supported (read-only)
| | `s3://` | `gs://` | `http(s)://` | local |
|---|---|---|---|---|
| zarr v2 | ✓ | ✓ | ✓ | ✓ |
| zarr v3 | ✓ | ✓ | ✓ | ✓ |
| N5 | ✓ | ✓ | ✓ | ✓ |
| neuroglancer precomputed | ✓ | ✓ | ✓ | ✓ |

For precomputed, all three URL styles work and are equivalent: bare (`s3://bucket/vol`), `/<scale-key>` suffix (`s3://bucket/vol/s0`), and explicit `precomputed://s3://bucket/vol`. Scale selection follows neuroglancer's convention — the trailing path segment is matched against `info["scales"][i]["key"]`, defaulting to scale 0 (highest resolution) when no suffix is present.

### CI
- Matrix expanded to `{ ubuntu-latest, macos-latest }` × `{ python 3.12 }` with `fail-fast: false` so a flake on one OS doesn't kill the other.
- Triggers are `push` on `main` + `pull_request`, so feature-branch pushes only fire one CI run per push (via the PR), not four.
- Codecov upload gated to the ubuntu run to avoid double-reporting.
- Added an `_available_cpu_count()` shim that falls back to `os.cpu_count()` on macOS where `os.sched_getaffinity` doesn't exist.

### Tests
End-to-end against an in-process moto S3 server. Test buckets get a public-read policy because cellmap data on real S3 is public-read — that's what makes unsigned metadata reads work in production.

- **`test_s3_read_zarr_via_idi`** — write a zarr to mock S3 with OME multiscales, open via `ImageDataInterface("s3://...")`. Verifies `voxel_size`, the center→corner-converted `offset`, and that `to_ndarray_ts` returns the exact bytes uploaded.
- **`test_s3_read_picks_correct_multiscale_level`** — multi-level group, open both s0 and s1 over S3, verify each level reports its own scale and translation.
- **`test_precomputed_read_local`** — author a 1-scale precomputed volume via tensorstore locally, open through `ImageDataInterface`, verify filetype detection, voxel_size, corner offset (from `voxel_offset * resolution`), and bit-exact round-trip via `to_ndarray_ts`.
- **`test_precomputed_read_with_scale_suffix`** — opening `.../vol/s0` resolves through the info file's `scales[].key`.
- **`test_precomputed_read_with_explicit_prefix`** — `precomputed://` prefix is accepted and equivalent to the bare path.
- **`test_precomputed_read_s3`** — same round-trip but mirrored to mock S3, so the info probe goes through `urlopen` and chunks go through tensorstore's S3 driver — the exact path a real public-bucket read takes.

Full suite: **232 passed**. No new runtime deps. `[dev]` extra picks up `moto[s3,server]` for the mock; the previous `[s3]` extra (which pulled in `s3fs`) is removed — nothing pulls in `s3fs` now.

### Out of scope
- **Writes to remote**: not supported. Attempting `mode != "r"` raises with a clear message.
- **Private S3 buckets**: cellmap data on AWS is public-read so unsigned `urlopen` for the metadata probe works. For private buckets, the metadata-probe path would 403; the data-read path (tensorstore) can sign with AWS credentials. If/when we need private-bucket support, the metadata probe needs to grow signing — not in this PR.
