### PR TITLE
Unpin fastremap (upstream bug fixed)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
 
 dependencies = [
   "bokeh>=3.1.0",
-  "fastremap==1.15.2",
+  "fastremap",
   "funlib.geometry",
   "numpy",
   "pandas",


### PR DESCRIPTION
## Summary

Removes the `fastremap==1.15.2` pin. It was added in 2b6fb0b to work around [seung-lab/fastremap#49](https://github.com/seung-lab/fastremap/issues/49) (`fastremap.unique return_inverse occasionally fails`), which was closed upstream on 2025-07-23. The call site at [`measure_util.py:135`](https://github.com/janelia-cellmap/cellmap-analyze/blob/main/src/cellmap_analyze/util/measure_util.py#L135) is unchanged — only the version constraint moves.

Verified locally on fastremap 1.20.0: full suite passes 232/232.