### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cellmap-analyze"
-version = "0.3.1"
+version = "0.4.0"
 description = "Code to perform analysis on segmentations like those produced by CellMap"
 readme = "README.md"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary

Minor version bump 0.3.1 → 0.4.0 in preparation for a PyPI release. Tagging `v0.4.0` after this merges triggers the release workflow (Linux + macOS wheels → PyPI → GitHub release).

Notable changes since 0.3.1:

- **Read-only support for zarr/N5/precomputed datasets on S3/GS/HTTP** (#78) — tensorstore-native, no fsspec/s3fs. macOS added to the CI matrix.
- **Per-instance UUID on tmp/merge dirs** (#77) — avoids collisions when multiple instances run in parallel.
- **Unpin fastremap** (#79, recommended to merge first) — upstream bug fix released, pin is no longer needed.

If #79 merges after this one, 0.4.0 will ship with the stale fastremap pin; merging #79 first keeps the released version clean.