### PR TITLE
Default S3 reads to anonymous mode when no AWS creds are set

### DIFF
--- a/src/cellmap_analyze/util/io_util.py
+++ b/src/cellmap_analyze/util/io_util.py
@@ -545,6 +545,19 @@ def kvstore_for_path(path):
         endpoint = os.environ.get("AWS_ENDPOINT_URL")
         if endpoint:
             kv["endpoint"] = endpoint
+        # Default to anonymous mode for public-bucket reads (OpenOrganelle,
+        # most cellmap-published data) so they don't pay multi-second
+        # IMDS / profile / web-identity timeouts in the tensorstore S3
+        # driver's credential chain. Users with private S3 access opt in
+        # via env -- any of AWS_ACCESS_KEY_ID / AWS_PROFILE /
+        # AWS_ENDPOINT_URL switches back to the default credential chain.
+        # (Moto tests already set AWS_ACCESS_KEY_ID + AWS_ENDPOINT_URL,
+        # so they're unaffected.)
+        if not any(
+            os.environ.get(k)
+            for k in ("AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_ENDPOINT_URL")
+        ):
+            kv["aws_credentials"] = {"type": "anonymous"}
         return kv, parsed.path.lstrip("/")
     if scheme == "gs":
         return {"driver": "gcs", "bucket": parsed.netloc}, parsed.path.lstrip("/")

--- a/tests/test_kvstore_anonymous.py
+++ b/tests/test_kvstore_anonymous.py
@@ -1,0 +1,65 @@
+"""``kvstore_for_path`` defaults s3:// reads to anonymous mode when no
+AWS credentials are configured -- this is what makes public-bucket
+reads (e.g. OpenOrganelle) fast instead of paying multi-second
+IMDS/credential-chain timeouts inside tensorstore.
+"""
+from __future__ import annotations
+
+import pytest
+
+from cellmap_analyze.util.io_util import kvstore_for_path
+
+_CRED_VARS = ("AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_ENDPOINT_URL")
+
+
+@pytest.fixture
+def no_aws_env(monkeypatch):
+    for k in _CRED_VARS:
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_s3_default_anonymous_when_no_creds(no_aws_env):
+    """No AWS env vars → kvstore gets aws_credentials={type: anonymous}."""
+    kv, key = kvstore_for_path("s3://janelia-cosem-datasets/jrc_hela-2/foo.zarr")
+    assert kv["driver"] == "s3"
+    assert kv["bucket"] == "janelia-cosem-datasets"
+    assert kv.get("aws_credentials") == {"type": "anonymous"}
+    assert key == "jrc_hela-2/foo.zarr"
+
+
+@pytest.mark.parametrize(
+    "var,value",
+    [
+        ("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE"),
+        ("AWS_PROFILE", "default"),
+        ("AWS_ENDPOINT_URL", "http://localhost:9000"),
+    ],
+)
+def test_s3_honors_creds_env_var(no_aws_env, monkeypatch, var, value):
+    """Any of the credential-related env vars switches off anonymous mode
+    so the tensorstore default credential chain is used (or the moto
+    endpoint, etc)."""
+    monkeypatch.setenv(var, value)
+    kv, _ = kvstore_for_path("s3://bucket/key")
+    assert "aws_credentials" not in kv
+
+
+def test_endpoint_url_still_attached(no_aws_env, monkeypatch):
+    """When AWS_ENDPOINT_URL is set (moto / MinIO), the kvstore should
+    pick it up AND skip anonymous mode."""
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://127.0.0.1:9000")
+    kv, _ = kvstore_for_path("s3://bucket/key")
+    assert kv["endpoint"] == "http://127.0.0.1:9000"
+    assert "aws_credentials" not in kv
+
+
+def test_non_s3_schemes_unaffected(no_aws_env):
+    """gs / http / file kvstores don't get aws_credentials injected."""
+    for url in (
+        "gs://bucket/key",
+        "https://example.com/key",
+        "file:///tmp/foo",
+        "/tmp/foo",
+    ):
+        kv, _ = kvstore_for_path(url)
+        assert "aws_credentials" not in kv


### PR DESCRIPTION
## Summary

Fixes an ~8× slowdown on public-bucket S3 reads (OpenOrganelle, most cellmap-published data) caused by tensorstore's S3 driver walking the full AWS credential chain — IMDS, profile, web-identity — and waiting for each to time out before falling through to anonymous mode. Off-EC2 that's ~6–7 seconds of dead time on every fresh open.

When **none** of `AWS_ACCESS_KEY_ID` / `AWS_PROFILE` / `AWS_ENDPOINT_URL` is present in the environment, `kvstore_for_path` now injects `aws_credentials: {type: "anonymous"}` into the S3 kvstore spec so the credential chain is skipped entirely.

Setting any of those three opts back into the default chain — covering:
- Explicit env credentials (`AWS_ACCESS_KEY_ID`).
- Profile users (`AWS_PROFILE=default`; users with only `~/.aws/credentials` and no env need to set this to opt in).
- Moto / MinIO / self-hosted S3-compatible endpoints (`AWS_ENDPOINT_URL`).

### Measured impact (real OpenOrganelle)

`s3://janelia-cosem-datasets/jrc_hela-2/jrc_hela-2.zarr/recon-1/em/fibsem-uint8/s5`:

|              | before | after |
|--------------|--------|-------|
| open IDI     | 3.66s  | 0.65s |
| first read   | 3.23s  | 0.23s |
| **total**    | 6.89s  | 0.88s |

Same bytes returned; mean voxel value 172.7 either way.

### Tests

6 new unit tests in `tests/test_kvstore_anonymous.py` covering:
- No env → anonymous mode injected.
- Each of `AWS_ACCESS_KEY_ID` / `AWS_PROFILE` / `AWS_ENDPOINT_URL` switches anonymous off.
- `AWS_ENDPOINT_URL` is still attached to the kvstore (so moto/MinIO works).
- `gs://`, `http(s)://`, `file://`, and bare local paths are untouched.

Existing moto-based tests (`test_s3_read.py`, `test_precomputed_read.py`) still pass because their fixtures set `AWS_ACCESS_KEY_ID`. Full suite: **238 passed**.

### Note for the release sequence
This should land before v0.4.0 is tagged so the headline "remote reads" feature in 0.4.0 actually runs at full speed by default.